### PR TITLE
Added timestamp string def

### DIFF
--- a/chef/cookbooks/cpe_utils/libraries/node_functions.rb
+++ b/chef/cookbooks/cpe_utils/libraries/node_functions.rb
@@ -67,6 +67,10 @@ class Chef
       username
     end
 
+    def ts
+      return ::Time.new.strftime("%Y%m%d%H%M%S")
+    end
+
     def serial
       unless macos?
         Chef::Log.warn('node.serial called on non-OS X!')


### PR DESCRIPTION
Returns date & time as a string, useful to backup config files
prior to changing them with templates.