### PR TITLE
Set munki install and configure false for quickstart json

### DIFF
--- a/chef/cookbooks/cpe_init/recipes/company_init.rb
+++ b/chef/cookbooks/cpe_init/recipes/company_init.rb
@@ -19,11 +19,10 @@ node.default['organization'] = 'MYCOMPANY'
 node.default['cpe_launchd']['prefix'] = 'com.MYCOMPANY.chef'
 node.default['cpe_profiles']['prefix'] = 'com.MYCOMPANY.chef'
 
-
 # Install munki
-node.default['cpe_munki']['install'] = true
+node.default['cpe_munki']['install'] = false
 # Configure munki
-node.default['cpe_munki']['configure'] = true
+node.default['cpe_munki']['configure'] = false
 # Override default munki settings
 node.default['cpe_munki']['preferences']['SoftwareRepoURL'] =
   'https://munki.MYCOMPANY.com/repo'


### PR DESCRIPTION
Cannot have munki install true until we provide everything needed for it to actually work. This can be changed back when it is functional out of the box. (Currently it is completely broken).