### PR TITLE
Move munki_catalog_items to /Library/Managed Installs/

### DIFF
--- a/chef/cookbooks/cpe_munki/resources/cpe_munki_local.rb
+++ b/chef/cookbooks/cpe_munki/resources/cpe_munki_local.rb
@@ -39,7 +39,7 @@ action :run do
 
   # This file is for context for users to know whats avalible for their machine
   pretty_json = JSON.pretty_generate(@catalog_items)
-  file '/opt/facebook/munki_catalog_items.json' do
+  file '/Library/Managed Installs/munki_catalog_items.json' do
     content pretty_json.to_s
   end
 end


### PR DESCRIPTION
Moves the /opt/facebook/munki_catalog_items.json file to a path that should exist by default on a Munki installs, /Library/Managed Installs/