### PR TITLE
refactor cpe_chrome

### DIFF
--- a/chef/cookbooks/cpe_chrome/README.md
+++ b/chef/cookbooks/cpe_chrome/README.md
@@ -11,13 +11,15 @@ Attributes
 ----------
 
 * node['cpe_chrome']
-* node['cpe_chrome']['ExtensionInstallForcelist']
-* node['cpe_chrome']['ExtensionInstallBlacklist']
-* node['cpe_chrome']['ExtensionInstallSources']
-* node['cpe_chrome']['EnabledPlugins']
-* node['cpe_chrome']['DisabledPlugins']
-* node['cpe_chrome']['DefaultPluginsSetting']
-* node['cpe_chrome']['PluginsAllowedForUrls']
+* node['cpe_chrome']['profile']['ExtensionInstallForcelist']
+* node['cpe_chrome']['profile']['ExtensionInstallBlacklist']
+* node['cpe_chrome']['profile']['ExtensionInstallSources']
+* node['cpe_chrome']['profile']['EnabledPlugins']
+* node['cpe_chrome']['profile']['DisabledPlugins']
+* node['cpe_chrome']['profile']['DefaultPluginsSetting']
+* node['cpe_chrome']['profile']['PluginsAllowedForUrls']
+* node['cpe_chrome']['mp']['UseMasterPreferences']
+* node['cpe_chrome']['mp']['FileContents']
 
 Usage
 -----
@@ -31,7 +33,7 @@ includes 3 recipes:
     * Manages all aspects of the Google Chrome Canary browser just for Mac OS X.
     * This recipe behaves identically to the Google Chrome recipe, and uses the same settings, but only applies if Chrome Canary is installed.
 
-`node['cpe_chrome']` is the hash that contains a hash of all the settings.  
+`node['cpe_chrome']['profile']` is the hash that contains a hash of all the settings.  
 
 The profile's organization key defaults to `Facebook` unless `node['organization']` is
 configured in your company's custom init recipe.
@@ -41,10 +43,10 @@ https://www.chromium.org/administrators/policy-list-3
 
 To add a managed setting to your profile, simply add the key from the URL list above to this hash:
 
-    node.default['cpe_chrome']['BookmarkBarEnabled'] = true
+    node.default['cpe_chrome']['profile']['BookmarkBarEnabled'] = true
 
 #### Extensions installed by policy
-`node['cpe_chrome']['ExtensionInstallForcelist']`  
+`node['cpe_chrome']['profile']['ExtensionInstallForcelist']`  
 
 * Extensions that are installed by policy (and cannot be disabled by the user)
 * Must be the extension ID followed by the Update URL.
@@ -59,21 +61,47 @@ To add your own, simply add to this array:
 
     # Install the LastPass extension  
     chrome_ext_update_url = 'https://clients2.google.com/service/update2/crx'
-    node.default['cpe_chrome']['ExtensionInstallForcelist'] <<
+    node.default['cpe_chrome']['profile']['ExtensionInstallForcelist'] <<
       "hdokiejnpimakedhajhdlcegeplioahd;#{chrome_ext_update_url}"
 
 Likewise, extensions can be blacklisted (and thus forcibly removed from your browser):
 
     # Forecefully remove the BetterHistory malware extension  
-    node.default['cpe_chrome']['ExtensionInstallBlacklist'] <<
+    node.default['cpe_chrome']['profile']['ExtensionInstallBlacklist'] <<
       "obciceimmggglbmelaidpjlmodcebijb"
 
-`node['cpe_chrome']['ExtensionInstallSources']` is a list of URL sources where extensions may be installed from.  See https://www.chromium.org/administrators/policy-list-3#ExtensionInstallSources for details.
+`node['cpe_chrome']['profile']['ExtensionInstallSources']` is a list of URL sources where extensions may be installed from.  See https://www.chromium.org/administrators/policy-list-3#ExtensionInstallSources for details.
+
+#### Master Preferences
+A Master Preferences file can be generated for use with first time Google Chrome is launched. This is useful if you would like to set "first-run" values, but not manage them.
+
+In order to use this, you must pass a `true` value to node['cpe_chrome']['mp']['UseMasterPreferences'].
+
+    node.default['cpe_chrome']['mp']['UseMasterPreferences'] = true
+
+As the Google Master Preferences file is inherently a JSON file, you can pass all attributes in a ruby hash:
+
+    # Set Master Preferences
+    node.default['cpe_chrome']['mp']['FileContents'] = {
+      'homepage' => 'https://example.tld',
+      'browser' => {
+        'show_home_button' => true
+      },
+      'bookmark_bar' => {
+        'show_on_all_tabs' => true
+      },
+      'distribution' => {
+        'skip_first_run_ui' => true,
+        'make_chrome_default' => true,
+        'make_chrome_default_for_user' => true,
+        'suppress_first_run_default_browser_prompt' => true
+      }
+    }
 
 #### Plugins
 Plugins can be enabled or disabled by policy.
 
-* `node['cpe_chrome']['EnabledPlugins']`
-* `node['cpe_chrome']['DisabledPlugins']`
+* `node['cpe_chrome']['profile']['EnabledPlugins']`
+* `node['cpe_chrome']['profile']['DisabledPlugins']`
 
 The enabled/disabled lists are arrays of values strings that can contain "*" or "?" wildcards.  See https://www.chromium.org/administrators/policy-list-3#EnabledPlugins for details.

--- a/chef/cookbooks/cpe_chrome/attributes/default.rb
+++ b/chef/cookbooks/cpe_chrome/attributes/default.rb
@@ -21,10 +21,10 @@ default['cpe_chrome']['profile'] = {
   'DisabledPlugins' => [],
   'DefaultPluginsSetting' => nil,
   'ExtensionInstallSources' => [],
-  'PluginsAllowedForUrls' => []
+  'PluginsAllowedForUrls' => [],
 }
 
 default['cpe_chrome']['mp'] = {
   'UseMasterPreferencesFile' => false,
-  'FileContents' => []
+  'FileContents' => [],
 }

--- a/chef/cookbooks/cpe_chrome/attributes/default.rb
+++ b/chef/cookbooks/cpe_chrome/attributes/default.rb
@@ -14,14 +14,17 @@
 # Google Chrome & Chrome Canary attributes
 # See https://www.chromium.org/administrators/policy-list-3
 
-default['cpe_chrome'] = {
-  'ExtensionInstallForcelist' => [
-  ],
-  'ExtensionInstallBlacklist' => [
-  ],
+default['cpe_chrome']['profile'] = {
+  'ExtensionInstallForcelist' => [],
+  'ExtensionInstallBlacklist' => [],
   'EnabledPlugins' => [],
   'DisabledPlugins' => [],
-  'DefaultPluginsSetting' => 1,
+  'DefaultPluginsSetting' => nil,
   'ExtensionInstallSources' => [],
-  'PluginsAllowedForUrls' => [],
+  'PluginsAllowedForUrls' => []
+}
+
+default['cpe_chrome']['mp'] = {
+  'UseMasterPreferencesFile' => false,
+  'FileContents' => []
 }

--- a/chef/cookbooks/cpe_chrome/resources/cpe_chrome.rb
+++ b/chef/cookbooks/cpe_chrome/resources/cpe_chrome.rb
@@ -119,7 +119,7 @@ action_class do
         group 'wheel'
         mode '0755'
         action :create
-        content "#{mprefs}"
+        content Chef::JSONCompat.to_json_pretty(mprefs)
       end
     end
   end


### PR DESCRIPTION
This PR is a breaking change, but I would like to outline the reasons:

Fixes:
1. cpe_chrome no longer installs itself when node values have not been configured in a cookbook
2. cpe_chrome no longer sets blank arrays in the profile.

New Features:
1. cpe_chrome can now manage the Google Chrome Master Preferences file using a standard hash.
```ruby
# Set Master Preferences
    node.default['cpe_chrome']['mp']['FileContents'] = {
      'homepage' => 'https://example.tld',
      'browser' => {
        'show_home_button' => true
      },
      'bookmark_bar' => {
        'show_on_all_tabs' => true
      },
      'distribution' => {
        'skip_first_run_ui' => true,
        'make_chrome_default' => true,
        'make_chrome_default_for_user' => true,
        'suppress_first_run_default_browser_prompt' => true
      }
    }
```

Breaking Changes:
1. 'DefaultPluginsSetting' is now a nil value (original value was int = 1)
2. cpe_chrome now has two namespaces: 'profile' and 'mp'

For item 2, you must retroactively change your configurations:
Example:
From:
```ruby
node.default['cpe_chrome']['BookmarkBarEnabled'] = true
```

To:
```ruby
node.default['cpe_chrome']['profile']['BookmarkBarEnabled'] = true
```

I think these breaking changes are warranted, given the new features. Thoughts on code styling are surely welcome. :)


