### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-#IT-CPE tools
+# IT-CPE tools
 The IT-CPE ("Client Platform Engineering") repo contains a suite of tools that we use to manage our fleet of over 10,000 client
 machines.
 
@@ -7,24 +7,24 @@ machines.
 * Watch our [presentation at MacADUK](https://www.youtube.com/watch?v=VIzgMavUFRQ)
 
 
-####Code sync
+#### Code sync
 We are constantly developing functions to make our scripts more robust. Both functions and scripts are deployed to all client machines via 'code sync' to ensure the latest code is always running.
 
-####Autoinit
+#### Autoinit
 A common problem that our team ran into was sourcing functions in multiple
 libraries. In order to increase developer efficiency and code readability, we create 'autoinit' to automatically source functions into the script and introduce a global namespace.
 
-####Launch Daemon Init (LDI)
+#### Launch Daemon Init (LDI)
 We also noticed issues with our previous client management tool. Periodically, client machines would lose connection with the mangement tools and become unmanaged.
 Critical patches and updates were unable to be sent to the client. To solve this, we built "Launch Daemon Init (LDI)," a system daemon that runs scripts and functions on set intervals (startup, daily, every15, weekly).
 
-####_tools.py
+#### _tools.py
 While the bash functions greatly increased our productivity, we realized that bash made using more advanced data types and error handling difficult. Python has enabled use to write more robust scripts and handle errors/edge cases more easily. The modules folder contain abstractions we've built to make things such as validating network states easy.
 
-####Pyexec
+#### Pyexec
 Similiar to autoinit for bash, we wanted a solution to automatically import our custom modules. Pyexec handles the necessary path modifications so you can focus more time on writing powerful scripts.
 
-####AutoPkg Runner
+#### AutoPkg Runner
 This is an [AutoPkg](https://github.com/autopkg/autopkg/) wrapper script that makes use of git to handle importing items into Munki git repo. It creates a separate git feature branch and puts up a commit for each item that is imported, to help automate controlled flow of new packages into Munki.
 See the internal README for more information.
 


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
