### PR TITLE
fix Chrome canary to not manage Safari

### DIFF
--- a/chef/cookbooks/cpe_chrome/resources/cpe_chrome.rb
+++ b/chef/cookbooks/cpe_chrome/resources/cpe_chrome.rb
@@ -83,7 +83,7 @@ action_class do
             'PayloadEnabled'     => true,
             'PayloadDisplayName' => 'Chrome Canary',
             'PayloadContent'     => {
-              'com.apple.Safari' => {
+              'com.google.Chrome.canary' => {
                 'Forced' => [
                   {
                     'mcx_preference_settings' => prefs,


### PR DESCRIPTION
Found a bug when looking at rewriting some cookbooks.