### PR TITLE
fix: Munki prefs shouldn't have ruby nils

### DIFF
--- a/chef/cookbooks/cpe_munki/resources/cpe_munki_config.rb
+++ b/chef/cookbooks/cpe_munki/resources/cpe_munki_config.rb
@@ -19,6 +19,7 @@ action :config do
   return unless node['cpe_munki']['configure']
   organization = node['organization'] ? node['organization'] : 'Facebook'
   prefix = node['cpe_profiles']['prefix']
+  prefs = node['cpe_munki']['preferences'].reject { |_k, v| v.nil? }
   node.default['cpe_profiles']["#{prefix}.munki"] = {
     'PayloadIdentifier'        => "#{prefix}.munki",
     'PayloadRemovalDisallowed' => true,
@@ -40,7 +41,7 @@ action :config do
           'ManagedInstalls' => {
             'Forced' => [
               {
-                'mcx_preference_settings' => node['cpe_munki']['preferences'],
+                'mcx_preference_settings' => prefs,
               },
             ],
           },


### PR DESCRIPTION
When ruby parses the attributes for preferences it doesn't strip the
`nil` values and instead will write the value as <data> inside the
profile.

Example:
```
    <key>RecoveryKeyFile</key>
    <data>
BAgw
    </data>
```
This will render as `<040830>` inside of System Preferences.

This causes Munki to use this malformed data and is unable to
interpret it properly causing https://github.com/munki/munki/issues/799.
Munki can be more resilient to bad data but Chef shouldn't create the bad
data in the first place.