### PR TITLE
fix cpe_remote_file

### DIFF
--- a/chef/cookbooks/cpe_remote/resources/file.rb
+++ b/chef/cookbooks/cpe_remote/resources/file.rb
@@ -47,7 +47,12 @@ load_current_value do |desired| # ~FC006
     checksum checksum_ondisk
     unless platform?('windows')
       owner Etc.getpwuid(f_stat.uid).name
-      group Etc.getgrgid(f_stat.gid).name
+      begin
+        current_group = Etc.getgrgid(f_stat.gid).name
+      rescue ArgumentError
+        current_group = nil
+      end
+      group current_group
       m = f_stat.mode
       mode "0#{(m & 07777).to_s(8)}"
     end


### PR DESCRIPTION
Sometimes the group lookup in the cpe_remote_file resource fails using the Etc module.  This diff uses a begin/rescue clause in the group assignment to catch outliers and edge cases.  This change has been running for a few months at Facebook  and resolved a few edge case errors with this resource.