### PR TITLE
Changing Ohai syntax

### DIFF
--- a/chef/tools/chef_bootstrap.py
+++ b/chef/tools/chef_bootstrap.py
@@ -451,8 +451,8 @@ def bootstrap(force=False):
   # Adding Node name based on serial number, and Ohai config changes.
   global CLIENT_RB
   CLIENT_RB += '\n' + 'node_name \"%s\"' % serial
-  CLIENT_RB += '\n' + 'Ohai::Config[:plugin_path] << "/etc/chef/ohai_plugins"'
-  CLIENT_RB += '\n' + 'Ohai::Config[:disabled_plugins] = [:Passwd]'
+  CLIENT_RB += '\n' + 'ohai.directory = "/etc/chef/ohai_plugins"'
+  CLIENT_RB += '\n' + 'ohai.disabled_plugins = [:Passwd]'
 
   if not os.path.isdir('/etc/chef'):
     os.makedirs('/etc/chef')


### PR DESCRIPTION
This change is to update the Ohai syntax to work with latest Chef clients.

We found that until these changes were made, chef-client version 13.x did not respect the Ohai settings, specifically the `disabled_plugins` which caused our systems to experience the `:Passwd` bug where the system freezes. After making this change, the plugin is now actually disabled during a chef-client run.

See syntax here as well: https://docs.chef.io/ohai.html under the "Ohai Settings in client.rb" 