### PR TITLE
Add API cookbook to manage windows telemetry settings

### DIFF
--- a/chef/cookbooks/cpe_init/metadata.rb
+++ b/chef/cookbooks/cpe_init/metadata.rb
@@ -30,6 +30,7 @@ depends 'cpe_prompt_user'
 depends 'cpe_screensaver'
 depends 'cpe_spotlight'
 depends 'cpe_remote'
+depends 'cpe_win_telemetry'
 
 ## Web Browser API Cookbooks
 depends 'cpe_chrome'

--- a/chef/cookbooks/cpe_init/recipes/mac_os_x_init.rb
+++ b/chef/cookbooks/cpe_init/recipes/mac_os_x_init.rb
@@ -46,6 +46,10 @@ if node.macos?
     'cpe_launchd',
     'cpe_profiles',
   ]
+elsif node.windows?
+  run_list += [
+    'cpe_win_telemetry',
+  ]
 end
 
 # Log run_list

--- a/chef/cookbooks/cpe_utils/libraries/node_functions.rb
+++ b/chef/cookbooks/cpe_utils/libraries/node_functions.rb
@@ -98,7 +98,7 @@ class Chef
     def get_shard(serial: nil, salt: nil, chunks: 100)
       # grab the serial by platform if possible
       # return nil if not possible
-      serial = serial ? serial : node.serial
+      serial ||= node.serial
       serial = node.uuid if serial.nil?
       return 0 if serial.nil?
       if salt
@@ -292,7 +292,7 @@ class Chef
           installed_apps = Plist.parse_xml(
             '/Library/Managed Installs/ManagedInstallReport.plist',
           )['managed_installs_list'].map(&:downcase)
-        rescue
+        rescue Exception
           Chef::Log.warn(
             'cpe_utils/node.munki_installed:' +
             ' Failed to retrieve applications installed by Munki',

--- a/chef/cookbooks/cpe_utils/libraries/node_functions.rb
+++ b/chef/cookbooks/cpe_utils/libraries/node_functions.rb
@@ -292,7 +292,7 @@ class Chef
           installed_apps = Plist.parse_xml(
             '/Library/Managed Installs/ManagedInstallReport.plist',
           )['managed_installs_list'].map(&:downcase)
-        rescue Exception
+        rescue StandardError
           Chef::Log.warn(
             'cpe_utils/node.munki_installed:' +
             ' Failed to retrieve applications installed by Munki',

--- a/chef/cookbooks/cpe_utils/libraries/node_functions.rb
+++ b/chef/cookbooks/cpe_utils/libraries/node_functions.rb
@@ -231,10 +231,11 @@ class Chef
     end
 
     def os_at_least?(version)
-      case node['platform_family']
-      when 'mac_os_x'
-        Gem::Version.new(node['platform_version']) >= Gem::Version.new(version)
+      if arch?
+        # Arch is a rolling release so it's always at a sufficient version
+        return true
       end
+      Gem::Version.new(node['platform_version']) >= Gem::Version.new(version)
     end
 
     def os_at_least_or_lower?(version)
@@ -242,6 +243,10 @@ class Chef
       when 'mac_os_x'
         Gem::Version.new(node['platform_version']) <= Gem::Version.new(version)
       end
+    end
+
+    def arch?
+      return node['platform'] == 'arch'
     end
 
     def linux?

--- a/chef/cookbooks/cpe_utils/libraries/registry_functions.rb
+++ b/chef/cookbooks/cpe_utils/libraries/registry_functions.rb
@@ -1,0 +1,50 @@
+# Cookbook Name:: cpe_utils
+# Library::registry_functions
+#
+# vim: syntax=ruby:expandtab:shiftwidth=2:softtabstop=2:tabstop=2
+#
+# Copyright (c) 2017-present, Facebook, Inc.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree. An additional grant
+# of patent rights can be found in the PATENTS file in the same directory.
+#
+
+module CPE
+  module WindowsRegistry
+    # Function which will return a hash which can be consumed by the values
+    # property of the registry_key resrouce.  Provide the function the hash and
+    # data_type of the registry key if needed.  We will try and automatically
+    # detect the data_type, however please verify the returned hash is correct
+    # as data_type detection needs to be refined for all edge cases.
+    def create_registry_hash(data)
+      hash = []
+      data.each do |name, value|
+        data_type = reg_data_type(value)
+        hash << { :name => name, :type => data_type, :data => value }
+      end
+      return hash
+    end
+
+    # First pass at determining data type for registry, verify returned data
+    # type is correct as type detection needs to be refined for all edge cases.
+    def reg_data_type(data)
+      data_type = :dword
+      case data
+      when String
+        data_type = :string
+        if data.include?('%')
+          data_type = :expand_string
+        end
+      when Bignum # rubocop:disable Lint/UnifiedInteger
+        data_type = :qword
+      end
+      return data_type
+    end
+  end
+end
+
+Chef::Recipe.send(:include, ::CPE::WindowsRegistry)
+Chef::Resource.send(:include, ::CPE::WindowsRegistry)
+Chef::Provider.send(:include, ::CPE::WindowsRegistry)

--- a/chef/cookbooks/cpe_win_telemetry/README.md
+++ b/chef/cookbooks/cpe_win_telemetry/README.md
@@ -1,0 +1,33 @@
+cpe_win_telemetry Cookbook
+===================
+This cookbook manages the telemetry settings on Windows machines. These settings
+specify the amount and detail of data sent to Microsoft on a Windows node.
+More information can be found here: https://docs.microsoft.com/en-us/windows/configuration/configure-windows-telemetry-in-your-organization
+
+Attributes
+----------
+* node['cpe_win_telemetry']['AllowTelemetry']
+
+Usage
+-----
+Manages the telemetry settings on a Windows node
+node['cpe_win_telemetry']['AllowTelemetry'].
+
+The following values can be given to this attribute.
+-1 : disable telemetry completely by setting the telemetry level to '0' which
+is the minimum value MS allows.  Then disables two services which the telemetry
+services relies on.  These are DiagTrack and dmwappushservice.
+
+0 : Security level. Security data only.
+1 : Basic level. Everything in 0 and basic system and quality data.
+2 : Enhanced level. Everything in 1 and enhanced insights and advanced
+     reliability data.
+3 : Full level. Everything in 2 and full diagnostics.
+
+For example, to disable telemetry just set the attribute as follows:
+
+    node.default['cpe_win_telemetry'] = {
+      'AllowTelemetry' => -1,
+    }
+
+If nothing is set, Microsoft defaults to level 3.

--- a/chef/cookbooks/cpe_win_telemetry/attributes/defaults.rb
+++ b/chef/cookbooks/cpe_win_telemetry/attributes/defaults.rb
@@ -1,0 +1,17 @@
+#
+# Cookbook Name:: cpe_win_telemetry
+# Attributes:: default
+#
+# vim: syntax=ruby:expandtab:shiftwidth=2:softtabstop=2:tabstop=2
+#
+# Copyright (c) 2017-present, Facebook, Inc.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree. An additional grant
+# of patent rights can be found in the PATENTS file in the same directory.
+#
+
+default['cpe_win_telemetry'] = {
+  'AllowTelemetry' => nil,
+}

--- a/chef/cookbooks/cpe_win_telemetry/metadata.rb
+++ b/chef/cookbooks/cpe_win_telemetry/metadata.rb
@@ -1,0 +1,10 @@
+# vim: syntax=ruby:expandtab:shiftwidth=2:softtabstop=2:tabstop=2
+name 'cpe_win_telemetry'
+maintainer 'Facebook'
+maintainer_email 'noreply@facebook.com'
+license 'All rights reserved'
+description 'Installs/Configures cpe_win_telemetry'
+long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
+version '0.1.0'
+
+depends 'cpe_utils'

--- a/chef/cookbooks/cpe_win_telemetry/recipes/default.rb
+++ b/chef/cookbooks/cpe_win_telemetry/recipes/default.rb
@@ -11,6 +11,4 @@
 # LICENSE file in the root directory of this source tree. An additional grant
 # of patent rights can be found in the PATENTS file in the same directory.
 #
-
-return unless node.windows? && node.os_at_least?('10.0.15063')
 cpe_win_telemetry 'Configure Windows Telemetry Settings'

--- a/chef/cookbooks/cpe_win_telemetry/recipes/default.rb
+++ b/chef/cookbooks/cpe_win_telemetry/recipes/default.rb
@@ -1,0 +1,16 @@
+#
+# Cookbook Name:: cpe_win_telemetry
+# Recipe:: default
+#
+# vim: syntax=ruby:expandtab:shiftwidth=2:softtabstop=2:tabstop=2
+#
+# Copyright (c) 2017-present, Facebook, Inc.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree. An additional grant
+# of patent rights can be found in the PATENTS file in the same directory.
+#
+
+return unless node.windows? && node.os_at_least?('10.0.15063')
+cpe_win_telemetry 'Configure Windows Telemetry Settings'

--- a/chef/cookbooks/cpe_win_telemetry/resources/cpe_win_telemetry.rb
+++ b/chef/cookbooks/cpe_win_telemetry/resources/cpe_win_telemetry.rb
@@ -23,7 +23,7 @@ action :config do
       # Disable these services to kill telemetry data to Microsoft
       windows_service svc_name do
         startup_type :disabled
-        action [:disable, :stop]
+        action %i[disable stop]
       end
     end
     # Reset Telemetry to min allowed value

--- a/chef/cookbooks/cpe_win_telemetry/resources/cpe_win_telemetry.rb
+++ b/chef/cookbooks/cpe_win_telemetry/resources/cpe_win_telemetry.rb
@@ -1,0 +1,39 @@
+#
+# Cookbook Name:: cpe_win_telemetry
+# Resource:: cpe_win_telemetry
+#
+# vim: syntax=ruby:expandtab:shiftwidth=2:softtabstop=2:tabstop=2
+#
+# Copyright (c) 2017-present, Facebook, Inc.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree. An additional grant
+# of patent rights can be found in the PATENTS file in the same directory.
+#
+
+resource_name :cpe_win_telemetry
+default_action :config
+provides :cpe_win_telemetry, :os => 'windows'
+
+action :config do
+  return unless node.windows? && node.os_at_least?('10.0.15063')
+  if node['cpe_win_telemetry']['AllowTelemetry'] == -1
+    ['DiagTrack', 'dmwappushservice'].each do |svc_name|
+      # Disable these services to kill telemetry data to Microsoft
+      windows_service svc_name do
+        startup_type :disabled
+        action [:disable, :stop]
+      end
+    end
+    # Reset Telemetry to min allowed value
+    node.default['cpe_win_telemetry']['AllowTelemetry'] = 0
+  end
+  telemetry_path =
+    'HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\DataCollection'
+  registry_key telemetry_path do
+    only_if { node['cpe_win_telemetry'].values.any? }
+    values create_registry_hash(node['cpe_win_telemetry'])
+    recursive true
+  end
+end


### PR DESCRIPTION
API cookbook that will manage the windows telemetry settings on Windows nodes.  Also adds the registry_functions in cpe_utils.