### PR TITLE
Updating chef_bootstrap.py for 10.13

### DIFF
--- a/chef/tools/chef_bootstrap.py
+++ b/chef/tools/chef_bootstrap.py
@@ -235,9 +235,11 @@ def install_cli_tools():
   """Install the Xcode CLI tools, from Apple if necessary."""
   os_ver = get_os_version()
   # Install command line tools if necessary:
-  # 10.12 receipt name
-  receipt = 'com.apple.pkg.DevSDK_OSX1012'
-  desired_platform = 'macOS Sierra'
+  receipt = 'com.apple.pkg.DevSDK_macOS1013_Public'
+  desired_platform = 'macOS High Sierra'
+  if '10.12' in os_ver:
+      receipt = 'com.apple.pkg.DevSDK_OSX1012'
+      desired_platform = 'macOS Sierra'
   if '10.11' in os_ver:
     receipt = 'com.apple.pkg.DevSDK_OSX1011'
     desired_platform = 'OS X 10.11'


### PR DESCRIPTION
Noticed bootstrap was failing on 10.13 for the CLI Tools portion, so I decided to update the receipts:

Before
```
Checking for OS X CLI Tools... not installed.

Software update failed!
```

After:
```
Checking for OS X CLI Tools... installed.

Setting up Chef config files.

Checking for Chef install...

Obtaining Chef...

Downloading from Chef directly... downloaded from Chef.io.

Installing Chef.

installer: Package name is Chef Client

installer: Installing at base path /

installer: The install was successful.


Finished installing Chef.

Running client, saving output to /Library/Chef/Logs/bootstrap.log

Running client, saving output to /Library/Chef/Logs/bootstrap.log

Running client, saving output to /Library/Chef/Logs/bootstrap.log

Bootstrap complete!
```