### PR TITLE
Updating desired_platform string for 10.11

### DIFF
--- a/chef/tools/chef_bootstrap.py
+++ b/chef/tools/chef_bootstrap.py
@@ -242,7 +242,7 @@ def install_cli_tools():
       desired_platform = 'macOS Sierra'
   if '10.11' in os_ver:
     receipt = 'com.apple.pkg.DevSDK_OSX1011'
-    desired_platform = 'OS X 10.11'
+    desired_platform = 'macOS El Capitan'
   if (
     is_pkg_installed('com.apple.pkg.CLTools_Executables') != '0.0.0.0' and
     is_pkg_installed(receipt) != '0.0.0.0'


### PR DESCRIPTION
The Command line tools were renamed to be more in line with 10.12 and 10.13, so 10.11 machines would fail to download the Command Line Tools (I know... I'm ashamed we have 10.11 machines too 👎  ). The tools are now called "Command Line Tools (macOS El Capitan version 10.11) for Xcode."