### PR TITLE
Update .rubocop.yml

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -117,25 +117,28 @@ Style/ConditionalAssignment:
 #
 # Modified rules
 #
-LineLength:
+Metrics/LineLength:
   Max: 80
 
-DotPosition:
+Layout/DotPosition:
   EnforcedStyle: trailing
 
-HashSyntax:
+Style/HashSyntax:
   EnforcedStyle: hash_rockets
 
 Style/Documentation:
   Enabled: false
 
-TrailingCommaInLiteral:
+Style/TrailingCommaInArrayLiteral:
+  EnforcedStyleForMultiline: comma
+  
+Style/TrailingCommaInHashLiteral:
   EnforcedStyleForMultiline: comma
 
-TrailingCommaInArguments:
+Style/TrailingCommaInArguments:
   EnforcedStyleForMultiline: comma
 
-Style/IndentArray:
+Layout/IndentArray:
   EnforcedStyle: consistent
 
 Style/SignalException:


### PR DESCRIPTION
Travis tests are giving the following error:
```
.rubocop.yml: Style/IndentArray has the wrong namespace - should be Layout
Error: The `Style/TrailingCommaInLiteral` cop no longer exists. Please use `Style/TrailingCommaInArrayLiteral` and/or `Style/TrailingCommaInHashLiteral` instead.
(obsolete configuration found in .rubocop.yml, please update it)
```

Figure I'd update it, and it will catch more work for everyone. #backlog