### PR TITLE
Min max package, update readme and add additional functionality for virtual_type

### DIFF
--- a/chef/cookbooks/cpe_utils/README.md
+++ b/chef/cookbooks/cpe_utils/README.md
@@ -78,10 +78,61 @@ remote_pkg 'VMWareTools' do
 end
 ```
 
+#### node.virtual_macos_type ####
+This is similar to node.virtual?, except it will allow you to apply granular conditions based on virtual machine type. This is useful for scoping tools to specific virtualization platforms.
+
+```
+def parallels?
+  node.virtual_macos_type == 'parallels'
+end
+
+def vmware?
+  node.virtual_macos_type == 'vmware'
+end
+
+def virtualbox?
+  node.virtual_macos_type == 'virtualbox'
+end
+```
+
+#### node.min_package_installed? ####
+This allows you to wrap a conditional item, based on the package receipt version. This checks to see if the minimum receipt version is present.
+
+```
+launchd 'com.googlecode.munki.app_usage_monitor' do
+  keep_alive true
+  label 'com.googlecode.munki.app_usage_monitor'
+  program_arguments ['/usr/local/munki/app_usage_monitor']
+  run_at_load true
+  type 'agent'
+  action :enable
+  only_if do
+    node.min_package_installed?('com.googlecode.munki.app_usage', '3.3.0.3513')
+  end
+end
+```
+
+#### node.max_package_installed? ####
+This allows you to wrap a conditional item, based on the package receipt version. This checks to see if the maximum receipt version is present.
+
+```
+launchd 'com.googlecode.munki.app_usage_monitor' do
+  keep_alive true
+  label 'com.googlecode.munki.app_usage_monitor'
+  program_arguments ['/usr/local/munki/app_usage_monitor']
+  run_at_load true
+  type 'daemon'
+  action :enable
+  only_if do
+    node.max_package_installed?('com.googlecode.munki.app_usage', '3.2.1.3498')
+  end
+end
+```
+
 #### node.munki_installed? ####
 Returns true if the item is in munki's managed_installs list.
 ```
 if node.munki_installed?('Firefox') do
-  something 
+  something
 end
 ```

--- a/chef/cookbooks/cpe_utils/README.md
+++ b/chef/cookbooks/cpe_utils/README.md
@@ -78,20 +78,33 @@ remote_pkg 'VMWareTools' do
 end
 ```
 
-#### node.virtual_macos_type ####
+#### node.parallels? ####
 This is similar to node.virtual?, except it will allow you to apply granular conditions based on virtual machine type. This is useful for scoping tools to specific virtualization platforms.
 
 ```
-def parallels?
-  node.virtual_macos_type == 'parallels'
+remote_pkg 'parallels_tools'
+  only_if { node.parallels? }
+  source 'https://someserver/sometool.pkg'
 end
+```
 
-def vmware?
-  node.virtual_macos_type == 'vmware'
+#### node.vmware? ####
+This is similar to node.virtual?, except it will allow you to apply granular conditions based on virtual machine type. This is useful for scoping tools to specific virtualization platforms.
+
+```
+remote_pkg 'vmware_tools'
+  only_if { node.vmware? }
+  source 'https://someserver/sometool.pkg'
 end
+```
 
-def virtualbox?
-  node.virtual_macos_type == 'virtualbox'
+#### node.virtualbox? ####
+This is similar to node.virtual?, except it will allow you to apply granular conditions based on virtual machine type. This is useful for scoping tools to specific virtualization platforms.
+
+```
+remote_pkg 'virtualbox_tools'
+  only_if { node.virtualbox? }
+  source 'https://someserver/sometool.pkg'
 end
 ```
 

--- a/chef/cookbooks/cpe_utils/libraries/node_functions.rb
+++ b/chef/cookbooks/cpe_utils/libraries/node_functions.rb
@@ -356,5 +356,39 @@ class Chef
       paths = app_paths(bundle_identifier)
       !paths.empty?
     end
+
+    def min_package_installed?(pkg_identifier, min_pkg_version)
+      unless macos?
+        Chef::Log.warn('node.min_package_installed? called on non-OS X!')
+        return false
+      end
+      installed_pkg_version = shell_out(
+        "/usr/sbin/pkgutil --pkg-info \"#{pkg_identifier}\"",
+      ).run_command.stdout.to_s[/version: (.*)/, 1]
+      # Compare the installed version to the minimum version
+      if Gem::Version.new(installed_pkg_version) >= Gem::Version.new(
+        min_pkg_version)
+        return true
+      else
+        return false
+      end
+    end
+
+    def max_package_installed?(pkg_identifier, max_pkg_version)
+      unless macos?
+        Chef::Log.warn('node.max_package_installed? called on non-OS X!')
+        return false
+      end
+      installed_pkg_version = shell_out(
+        "/usr/sbin/pkgutil --pkg-info \"#{pkg_identifier}\"",
+      ).run_command.stdout.to_s[/version: (.*)/, 1]
+      # Compare the installed version to the maximum version
+      if Gem::Version.new(installed_pkg_version) <= Gem::Version.new(
+        max_pkg_version)
+        return true
+      else
+        return false
+      end
+    end
   end
 end

--- a/chef/cookbooks/cpe_utils/libraries/node_functions.rb
+++ b/chef/cookbooks/cpe_utils/libraries/node_functions.rb
@@ -378,7 +378,12 @@ class Chef
         "/usr/sbin/pkgutil --pkg-info \"#{pkg_identifier}\"",
       ).run_command.stdout.to_s[/version: (.*)/, 1]
       # Compare the installed version to the minimum version
-      Gem::Version.new(installed_pkg_version) >= Gem::Version.new(min_pkg)
+      unless installed_pkg_version.nil?
+        return Gem::Version.new(installed_pkg_version) >= Gem::Version.new(
+          min_pkg)
+      end
+      Chef::Log.warn("Package #{pkg_identifier} returned nil.")
+      return false
     end
 
     def max_package_installed?(pkg_identifier, max_pkg)
@@ -390,7 +395,12 @@ class Chef
         "/usr/sbin/pkgutil --pkg-info \"#{pkg_identifier}\"",
       ).run_command.stdout.to_s[/version: (.*)/, 1]
       # Compare the installed version to the maximum version
-      Gem::Version.new(installed_pkg_version) <= Gem::Version.new(max_pkg)
+      unless installed_pkg_version.nil?
+        return Gem::Version.new(installed_pkg_version) <= Gem::Version.new(
+          max_pkg)
+      end
+      Chef::Log.warn("Package #{pkg_identifier} returned nil.")
+      return false
     end
   end
 end

--- a/chef/cookbooks/cpe_utils/libraries/node_functions.rb
+++ b/chef/cookbooks/cpe_utils/libraries/node_functions.rb
@@ -378,12 +378,11 @@ class Chef
         "/usr/sbin/pkgutil --pkg-info \"#{pkg_identifier}\"",
       ).run_command.stdout.to_s[/version: (.*)/, 1]
       # Compare the installed version to the minimum version
-      unless installed_pkg_version.nil?
-        return Gem::Version.new(installed_pkg_version) >= Gem::Version.new(
-          min_pkg)
+      if installed_pkg_version.nil?
+        Chef::Log.warn("Package #{pkg_identifier} returned nil.")
+        return false
       end
-      Chef::Log.warn("Package #{pkg_identifier} returned nil.")
-      return false
+      Gem::Version.new(installed_pkg_version) >= Gem::Version.new(min_pkg)
     end
 
     def max_package_installed?(pkg_identifier, max_pkg)
@@ -395,12 +394,11 @@ class Chef
         "/usr/sbin/pkgutil --pkg-info \"#{pkg_identifier}\"",
       ).run_command.stdout.to_s[/version: (.*)/, 1]
       # Compare the installed version to the maximum version
-      unless installed_pkg_version.nil?
-        return Gem::Version.new(installed_pkg_version) <= Gem::Version.new(
-          max_pkg)
+      if installed_pkg_version.nil?
+        Chef::Log.warn("Package #{pkg_identifier} returned nil.")
+        return false
       end
-      Chef::Log.warn("Package #{pkg_identifier} returned nil.")
-      return false
+      Gem::Version.new(installed_pkg_version) <= Gem::Version.new(max_pkg)
     end
   end
 end

--- a/chef/cookbooks/cpe_utils/libraries/node_functions.rb
+++ b/chef/cookbooks/cpe_utils/libraries/node_functions.rb
@@ -273,6 +273,18 @@ class Chef
       return node['os'] == 'windows'
     end
 
+    def parallels?
+      return virtual_macos_type == 'parallels'
+    end
+
+    def vmware?
+      return virtual_macos_type == 'vmware'
+    end
+
+    def virtualbox?
+      return virtual_macos_type == 'virtualbox'
+    end
+
     # Does not work on OS X as it does not have this ohai plugin by default
     def virtual?
       if node['virtualization2']

--- a/chef/cookbooks/cpe_utils/libraries/node_functions.rb
+++ b/chef/cookbooks/cpe_utils/libraries/node_functions.rb
@@ -378,11 +378,7 @@ class Chef
         "/usr/sbin/pkgutil --pkg-info \"#{pkg_identifier}\"",
       ).run_command.stdout.to_s[/version: (.*)/, 1]
       # Compare the installed version to the minimum version
-      if Gem::Version.new(installed_pkg_version) >= Gem::Version.new(min_pkg)
-        return true
-      else
-        return false
-      end
+      Gem::Version.new(installed_pkg_version) >= Gem::Version.new(min_pkg)
     end
 
     def max_package_installed?(pkg_identifier, max_pkg)
@@ -394,11 +390,7 @@ class Chef
         "/usr/sbin/pkgutil --pkg-info \"#{pkg_identifier}\"",
       ).run_command.stdout.to_s[/version: (.*)/, 1]
       # Compare the installed version to the maximum version
-      if Gem::Version.new(installed_pkg_version) <= Gem::Version.new(max_pkg)
-        return true
-      else
-        return false
-      end
+      Gem::Version.new(installed_pkg_version) <= Gem::Version.new(max_pkg)
     end
   end
 end

--- a/chef/cookbooks/cpe_utils/libraries/node_functions.rb
+++ b/chef/cookbooks/cpe_utils/libraries/node_functions.rb
@@ -369,7 +369,7 @@ class Chef
       !paths.empty?
     end
 
-    def min_package_installed?(pkg_identifier, min_pkg_version)
+    def min_package_installed?(pkg_identifier, min_pkg)
       unless macos?
         Chef::Log.warn('node.min_package_installed? called on non-OS X!')
         return false
@@ -378,15 +378,14 @@ class Chef
         "/usr/sbin/pkgutil --pkg-info \"#{pkg_identifier}\"",
       ).run_command.stdout.to_s[/version: (.*)/, 1]
       # Compare the installed version to the minimum version
-      if Gem::Version.new(installed_pkg_version) >= Gem::Version.new(
-        min_pkg_version)
+      if Gem::Version.new(installed_pkg_version) >= Gem::Version.new(min_pkg)
         return true
       else
         return false
       end
     end
 
-    def max_package_installed?(pkg_identifier, max_pkg_version)
+    def max_package_installed?(pkg_identifier, max_pkg)
       unless macos?
         Chef::Log.warn('node.max_package_installed? called on non-OS X!')
         return false
@@ -395,8 +394,7 @@ class Chef
         "/usr/sbin/pkgutil --pkg-info \"#{pkg_identifier}\"",
       ).run_command.stdout.to_s[/version: (.*)/, 1]
       # Compare the installed version to the maximum version
-      if Gem::Version.new(installed_pkg_version) <= Gem::Version.new(
-        max_pkg_version)
+      if Gem::Version.new(installed_pkg_version) <= Gem::Version.new(max_pkg)
         return true
       else
         return false

--- a/chef/cookbooks/cpe_utils/libraries/node_functions.rb
+++ b/chef/cookbooks/cpe_utils/libraries/node_functions.rb
@@ -274,15 +274,15 @@ class Chef
     end
 
     def parallels?
-      return virtual_macos_type == 'parallels'
+      virtual_macos_type == 'parallels'
     end
 
     def vmware?
-      return virtual_macos_type == 'vmware'
+      virtual_macos_type == 'vmware'
     end
 
     def virtualbox?
-      return virtual_macos_type == 'virtualbox'
+      virtual_macos_type == 'virtualbox'
     end
 
     # Does not work on OS X as it does not have this ohai plugin by default


### PR DESCRIPTION
This allows you to do cool things like manage launchdaemons/agents dynamically depending on the version of software installed.

I am using this for Munki 3.2 -> 3.3 migration.