### PR TITLE
revert cpe_safari for 10.13.4 changes

### DIFF
--- a/chef/cookbooks/cpe_safari/resources/cpe_safari.rb
+++ b/chef/cookbooks/cpe_safari/resources/cpe_safari.rb
@@ -17,30 +17,35 @@ default_action :config
 action :config do
   safari_prefs = node['cpe_safari'].reject { |_k, v| v.nil? }
   return if safari_prefs.empty?
-
   prefix = node['cpe_profiles']['prefix']
   organization = node['organization'] ? node['organization'] : 'Facebook'
-  safari_profile = {
-    'PayloadIdentifier' => "#{prefix}.browsers.safari",
+  node.default['cpe_profiles']["#{prefix}.browsers.safari"] = {
+    'PayloadIdentifier'        => "#{prefix}.browsers.safari",
     'PayloadRemovalDisallowed' => true,
-    'PayloadScope' => 'System',
-    'PayloadType' => 'Configuration',
-    'PayloadUUID' => 'bf900530-2306-0131-32e2-000c2944c108',
-    'PayloadOrganization' => organization,
-    'PayloadVersion' => 1,
-    'PayloadDisplayName' => 'Safari',
-    'PayloadContent' => [{
-      'PayloadType' => 'com.apple.Safari',
-      'PayloadVersion' => 1,
-      'PayloadIdentifier' => "#{prefix}.browsers.safari",
-      'PayloadUUID' => '3377ead0-2310-0131-32ec-000c2944c108',
-      'PayloadEnabled' => true,
-      'PayloadDisplayName' => 'Safari',
-    }],
+    'PayloadScope'             => 'System',
+    'PayloadType'              => 'Configuration',
+    'PayloadUUID'              => 'bf900530-2306-0131-32e2-000c2944c108',
+    'PayloadOrganization'      => organization,
+    'PayloadVersion'           => 1,
+    'PayloadDisplayName'       => 'Safari',
+    'PayloadContent'           => [
+      {
+        'PayloadType'        => 'com.apple.ManagedClient.preferences',
+        'PayloadVersion'     => 1,
+        'PayloadIdentifier'  => "#{prefix}.browsers.safari",
+        'PayloadUUID'        => '3377ead0-2310-0131-32ec-000c2944c108',
+        'PayloadEnabled'     => true,
+        'PayloadDisplayName' => 'Safari',
+        'PayloadContent'     => {
+          'com.apple.Safari' => {
+            'Forced' => [
+              {
+                'mcx_preference_settings' => safari_prefs,
+              },
+            ],
+          },
+        },
+      },
+    ],
   }
-  safari_prefs.each do |k, v|
-    safari_profile['PayloadContent'][0][k] = v
-  end
-
-  node.default['cpe_profiles']["#{prefix}.browsers.safari"] = safari_profile
 end


### PR DESCRIPTION
As discovered [here](https://gist.github.com/erikng/97d9910ca16e86c720e667bbce6850a2), Apple has now prevented the Safari payload type from being installed via root, without further admin input.

This is more than likely a reaction to [this](https://blog.malwarebytes.com/threat-analysis/2018/04/new-crossrider-variant-installs-configuration-profiles-on-macs/). 

I have tested that MC X profile payloads are not impacted by this (for now), so I think we should unfortunately revert back to MC X.