### PR TITLE
cpe_profiles - use proper shell_out for listing profiles per OS version

### DIFF
--- a/chef/cookbooks/cpe_profiles/README.md
+++ b/chef/cookbooks/cpe_profiles/README.md
@@ -5,7 +5,8 @@ chef.
 
 Requirements
 ------------
-Mac OS X
+* Mac OS X
+* cpe_utils cookbook
 
 
 Attributes

--- a/chef/cookbooks/cpe_profiles/metadata.rb
+++ b/chef/cookbooks/cpe_profiles/metadata.rb
@@ -8,3 +8,5 @@ description 'Installs/Configures OS X confiuration profiles'
 long_description 'Installs/Configures OS X confiuration profiles'
 version '0.1.0'
 supports 'mac_os_x'
+
+depends 'cpe_utils'

--- a/chef/cookbooks/cpe_profiles/resources/cpe_profiles.rb
+++ b/chef/cookbooks/cpe_profiles/resources/cpe_profiles.rb
@@ -61,7 +61,14 @@ def find_managed_profile_identifiers
     end
   end
   current_identifiers = []
-  profiles_string = shell_out!('profiles -P -o stdout-xml')
+  if node.os_at_least?('10.13')
+    profiles_string = shell_out!('profiles list -output stdout-xml')
+  elsif node.os_at_least?('10.10')
+    profiles_string = shell_out!('profiles -P -o stdout-xml')
+  else
+    profiles_string = shell_out!('profiles -P -o stdout-xml; '\
+      'cat stdout-xml.plist')
+  end
   profiles = Plist.parse_xml(profiles_string.stdout)
   if profiles['_computerlevel']
     profiles['_computerlevel'].each do |profile|

--- a/chef/cookbooks/cpe_profiles/resources/cpe_profiles.rb
+++ b/chef/cookbooks/cpe_profiles/resources/cpe_profiles.rb
@@ -92,6 +92,7 @@ def find_managed_profile_identifiers
   else
     # 10.7 -> 10.9 require a legacy profile provider
     profiles = query_installed_profiles_legacy
+  end
   if profiles['_computerlevel']
     profiles['_computerlevel'].each do |profile|
       if profile['ProfileIdentifier'].start_with?(


### PR DESCRIPTION
10.13 and higher are now recommended to use `profiles list -output stdout-xml`  - doing this now so we don't get hit one day and things just start failing

10.10 through 10.12 can use `profiles -P -o stdout-xml`

10.7 through 10.9 must use `profiles -P -o stdout-xml`, but that actually creates a plist on disk at the current directory called `stdout-xml.plist`, so we must emit the resulting plist to get the same functionality as 10.10 and higher.