### PR TITLE
comment out cpe_hosts in cpe_init...

### DIFF
--- a/chef/cookbooks/cpe_init/metadata.rb
+++ b/chef/cookbooks/cpe_init/metadata.rb
@@ -17,7 +17,7 @@ depends 'cpe_utils'
 # depends 'cpe_autopkg' # requires 'mac_os_x' community cookbook
 depends 'cpe_bluetooth'
 depends 'cpe_desktop'
-depends 'cpe_hosts'
+# depends 'cpe_hosts' # requires 'line' community cookbook
 depends 'cpe_kms'
 depends 'cpe_launchd'
 depends 'cpe_macos_server'

--- a/chef/cookbooks/cpe_init/recipes/mac_os_x_init.rb
+++ b/chef/cookbooks/cpe_init/recipes/mac_os_x_init.rb
@@ -27,7 +27,7 @@ if node.macos?
     'cpe_bluetooth',
     'cpe_chrome',
     'cpe_desktop',
-    'cpe_hosts',
+    # 'cpe_hosts', # requires 'line' community cookbook
     'cpe_macos_server',
     'cpe_nightly_reboot',
     'cpe_pathsd',


### PR DESCRIPTION
...so that the Quickstart guide on https://github.com/facebook/IT-CPE/tree/master/chef will work. Otherwise, chef errors out because the community line cookbook is not available. 