### PR TITLE
fix: Correct syntax for folder_name in remote_file

### DIFF
--- a/chef/cookbooks/cpe_remote/resources/file.rb
+++ b/chef/cookbooks/cpe_remote/resources/file.rb
@@ -66,7 +66,7 @@ action :create do
     filename = new_resource.file_name ?
       new_resource.file_name : new_resource.folder_name
     file_source = new_resource.file_url ?
-      new_resource.file_url : gen_url(folder_name, filename)
+      new_resource.file_url : gen_url(new_resource.folder_name, filename)
     hders = new_resource.headers ?
       new_resource.headers : auth_headers(file_source, 'GET')
 


### PR DESCRIPTION
Without this change, `cpe_remote_file` fails to use the proper `folder_name` variable. Only tested this on Chef 14.

```bash
    * cpe_remote_file[/etc/chef/foo] action create[2018-07-13T15:17:47-05:00] INFO: Processing cpe_remote_file[/etc/chef/foo] action create (/really/long/paths/cookbooks/cpe_chef_client/resources/cpe_foo.rb line 22)
[2018-07-13T15:17:47-05:00] WARN: filename is: foo

      
      ================================================================================
      Error executing action `create` on resource 'cpe_remote_file[/etc/chef/foo]'
      ================================================================================
      
      NameError
      ---------
      undefined local variable or method `folder_name' for #<#<Class:0x00007fd2a6441d00>:0x00007fd2a20b5668>
      
      Cookbook Trace:
      ---------------
      /really/long/paths/cookbooks/cpe_remote/resources/file.rb:70:in `block (2 levels) in class_from_file'
      /really/long/paths/cookbooks/cpe_remote/resources/file.rb:65:in `block in class_from_file'
      
      Resource Declaration:
      ---------------------
      # In /really/long/paths/cpe_chef_helper.rb
      
       22:     cpe_remote_file file['install_path'] do
       23:       checksum file['checksum']
       24:       file_name file['file_name'] if file['file_name']
       25:       file_url file['file_url'] if file['file_url']
       26:       folder_name 'foo'
       27:       group node['root_group']
       28:       headers file['headers'] if file['headers']
       29:       mode 0755
       30:       owner d_owner
       31:       path file['install_path']
       32:     end
       33:   end
      
```