### PR TITLE
Add MAU pref domain functionality

### DIFF
--- a/chef/cookbooks/cpe_office/README.md
+++ b/chef/cookbooks/cpe_office/README.md
@@ -16,3 +16,5 @@ No extra work is required, and no features are customizable.
 If Microsoft Outlook 2016 (com.microsoft.Outlook) is installed, this profile will be applied to configure Word, PowerPoint, Excel, and OneNote products to suppress first run behavior.
 
 Note that Outlook itself does NOT have this suppressed, as the first run windows are necessary to set up an account for a new user.
+
+The MAU aspects of this cookbook will manage the `com.microsoft.autoupdate2` preference domain. Further info can be found at: https://macadmins.software/docs/MAU_38.pdf

--- a/chef/cookbooks/cpe_office/attributes/default.rb
+++ b/chef/cookbooks/cpe_office/attributes/default.rb
@@ -28,6 +28,16 @@ default['cpe_office']['win']['manage_reg'] = {
 }
 
 default['cpe_office']['mac'] = {
+  'mau' => {
+    'ChannelName' => nil,
+    'DisableInsiderCheckbox' => nil,
+    'ExtendedLogging' => nil,
+    'HowToCheck' => nil,
+    'ManifestServer' => nil,
+    'SendAllTelemetryEnabled' => nil,
+    'StartDaemonOnAppLaunch' => nil,
+    'UpdateCache' => nil,
+  },
   'o365' => {
     'SendAllTelemetryEnabled' => nil,
   },

--- a/chef/cookbooks/cpe_office/resources/darwin.rb
+++ b/chef/cookbooks/cpe_office/resources/darwin.rb
@@ -16,6 +16,7 @@ provides :cpe_office_darwin, :os => 'darwin'
 default_action :manage
 
 action :manage do
+  mau_prefs = node['cpe_office']['mac']['mau'].reject { |_k, v| v.nil? }
   o365_prefs = node['cpe_office']['mac']['o365'].reject { |_k, v| v.nil? }
   onenote_prefs = node['cpe_office']['mac']['onenote'].reject { |_k, v| v.nil? }
   excel_prefs = node['cpe_office']['mac']['excel'].reject { |_k, v| v.nil? }
@@ -24,6 +25,7 @@ action :manage do
   word_prefs = node['cpe_office']['mac']['word'].reject { |_k, v| v.nil? }
 
   if [
+    mau_prefs,
     o365_prefs,
     onenote_prefs,
     excel_prefs,
@@ -33,6 +35,17 @@ action :manage do
   ].all?(&:empty?)
     Chef::Log.info("#{cookbook_name}: prefs not found.")
     return
+  end
+
+  unless mau_prefs.empty?
+    {
+      'PayloadEnabled' => true,
+      'PayloadIdentifier' => '447f7d4d-572d-4308-8e59-e51478f03a5c',
+      'PayloadDescription' => 'Microsoft Autoupdate Settings',
+      'PayloadVersion' => 1,
+      'PayloadType' => 'com.microsoft.autoupdate2',
+      'PayloadUUID' => '447f7d4d-572d-4308-8e59-e51478f03a5c',
+    }.each { |k, v| mau_prefs[k] = v }
   end
 
   unless o365_prefs.empty?
@@ -119,6 +132,7 @@ action :manage do
   }
 
   [
+    mau_prefs,
     o365_prefs,
     onenote_prefs,
     excel_prefs,


### PR DESCRIPTION
This PR will extend `cpe_office` to also manage keys for the `com.microsoft.autoupdate2` (Microsoft Autoupdate 2.0) preference domain.