### PR TITLE
Update .travis.yml for Ruby 2.4.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: ruby
 rvm:
- - 2.2.2
+ - 2.4.1
 # uncomment and edit the following line if your project needs to run something other than `rake`:
 gemfile:
   Gemfile


### PR DESCRIPTION
Upgrading the version of ruby used for tests. Seems a good amount of gems were updated since the fix went out. 

I'm not too sure if updating the ruby version will lint for chef 14, but I'm making the change to see. I do understand the cookbooks in this repo are not 14 ready.