### PR TITLE
Update cpe_pathsd to work on Linux

### DIFF
--- a/chef/cookbooks/cpe_pathsd/files/default/paths
+++ b/chef/cookbooks/cpe_pathsd/files/default/paths
@@ -1,0 +1,5 @@
+/usr/local/bin
+/usr/bin
+/bin
+/usr/sbin
+/sbin

--- a/chef/cookbooks/cpe_pathsd/metadata.rb
+++ b/chef/cookbooks/cpe_pathsd/metadata.rb
@@ -8,3 +8,5 @@ description 'Installs/Configures cpe_pathsd'
 long_description 'Installs/Configures cpe_pathsd'
 version '0.1.0'
 supports 'mac_os_x'
+
+depends 'cpe_utils'

--- a/chef/cookbooks/cpe_pathsd/recipes/darwin.rb
+++ b/chef/cookbooks/cpe_pathsd/recipes/darwin.rb
@@ -1,6 +1,6 @@
 #
 # Cookbook Name:: cpe_pathsd
-# Recipe:: default
+# Recipe:: darwin
 #
 # vim: syntax=ruby:expandtab:shiftwidth=2:softtabstop=2:tabstop=2
 #
@@ -12,5 +12,24 @@
 # of patent rights can be found in the PATENTS file in the same directory.
 #
 
-return if node.windows?
-include_recipe "cpe_pathsd::#{node['os']}"
+directory '/etc/paths.d/' do
+  owner 'root'
+  group 'wheel'
+  mode 0755
+end
+
+template '/etc/paths.d/cpe_pathsd' do
+  source 'cpe_pathsd'
+  owner 'root'
+  group 'wheel'
+  mode 0644
+end
+
+# No one should have the ability to update /etc/paths though an API.
+cookbook_file '/etc/paths' do
+  source 'paths'
+  owner root_owner
+  group root_group
+  mode 0644
+  action :create
+end

--- a/chef/cookbooks/cpe_pathsd/recipes/linux.rb
+++ b/chef/cookbooks/cpe_pathsd/recipes/linux.rb
@@ -1,6 +1,6 @@
 #
 # Cookbook Name:: cpe_pathsd
-# Recipe:: default
+# Recipe:: linux
 #
 # vim: syntax=ruby:expandtab:shiftwidth=2:softtabstop=2:tabstop=2
 #
@@ -12,5 +12,15 @@
 # of patent rights can be found in the PATENTS file in the same directory.
 #
 
-return if node.windows?
-include_recipe "cpe_pathsd::#{node['os']}"
+directory '/etc/profile.d' do
+  owner root_owner
+  group root_group
+  mode '0755'
+end
+
+template '/etc/profile.d/cpe_paths.sh' do
+  source 'profile.d_paths.erb'
+  owner root_owner
+  group root_group
+  mode '0644'
+end

--- a/chef/cookbooks/cpe_pathsd/templates/default/cpe_pathsd
+++ b/chef/cookbooks/cpe_pathsd/templates/default/cpe_pathsd
@@ -1,3 +1,3 @@
-<% node['cpe_pathsd'].each do |path| %>
+<% node['cpe_pathsd'].sort.uniq.each do |path| %>
 <%="#{path}"%>
 <% end %>

--- a/chef/cookbooks/cpe_pathsd/templates/default/profile.d_paths.erb
+++ b/chef/cookbooks/cpe_pathsd/templates/default/profile.d_paths.erb
@@ -1,0 +1,7 @@
+<% node['cpe_pathsd'].sort.uniq.each do |path| -%>
+[ -d "<%= path %>" ] && PATH="${PATH}:<%= path %>"
+<% end -%>
+
+<%- unless node['cpe_pathsd'].empty? -%>
+export PATH
+<%- end -%>


### PR DESCRIPTION
This updates `cpe_pathsd` to move the existing resources to a Darwin-specific recipe and ensures a sane default path is always enforced.

Also introduce a Linux recipe. The API is the same on both platforms, but on Linux the result is only compatible with Bourne-compatible POSIX shells (`bash`, `zsh`, etc.).

On both Darwin and Linux, remove any duplicate path entries that may have been added to the list.