### PR TITLE
Fixed typo in `cpe_powermanagement` readme

### DIFF
--- a/chef/cookbooks/cpe_powermanagement/README.md
+++ b/chef/cookbooks/cpe_powermanagement/README.md
@@ -12,13 +12,13 @@ This can be run on any OS X machine, but this is really intended to only apply t
 
 Attributes
 ----------
-* node['cpe_powermanagement']['AC']['Automatic Restart On Power Loss']
-* node['cpe_powermanagement']['AC']['Disk Sleep Timer']
-* node['cpe_powermanagement']['AC']['Display Sleep Timer']
-* node['cpe_powermanagement']['AC']['Sleep On Power Button']
-* node['cpe_powermanagement']['AC']['System Sleep Timer']
-* node['cpe_powermanagement']['AC']['Wake On LAN']
-* node['cpe_powermanagement']['AC']['RestartAfterKernelPanic']
+* node['cpe_powermanagement']['ACPower']['Automatic Restart On Power Loss']
+* node['cpe_powermanagement']['ACPower']['Disk Sleep Timer']
+* node['cpe_powermanagement']['ACPower']['Display Sleep Timer']
+* node['cpe_powermanagement']['ACPower']['Sleep On Power Button']
+* node['cpe_powermanagement']['ACPower']['System Sleep Timer']
+* node['cpe_powermanagement']['ACPower']['Wake On LAN']
+* node['cpe_powermanagement']['ACPower']['RestartAfterKernelPanic']
 
 * node['cpe_powermanagement']['Battery']['Automatic Restart On Power Loss']
 * node['cpe_powermanagement']['Battery']['Disk Sleep Timer']
@@ -43,25 +43,25 @@ configured in your company's custom init recipe.
 
 The supported and provided keys all live in `node['cpe_powermanagement']`:
 
-* `node['cpe_powermanagement']['AC']['Automatic Restart On Power Loss']`  
+* `node['cpe_powermanagement']['ACPower']['Automatic Restart On Power Loss']`  
 Automatically restart if a power failure occurs  
 **Values**: true/false  
-* `node['cpe_powermanagement']['AC']['Disk Sleep Timer']`  
+* `node['cpe_powermanagement']['ACPower']['Disk Sleep Timer']`  
 Put hard disks to sleep after this idle time  
 **Values**: Integer, number of minutes  
-* `node['cpe_powermanagement']['AC']['Display Sleep Timer']`  
+* `node['cpe_powermanagement']['ACPower']['Display Sleep Timer']`  
 Put monitor/display to sleep after this idle time  
 **Values**: Integer, number of minutes  
-* `node['cpe_powermanagement']['AC']['Sleep On Power Button']`  
+* `node['cpe_powermanagement']['ACPower']['Sleep On Power Button']`  
 Pressing the power button immediately invokes sleep  
 **Values**: true/false  
-* `node['cpe_powermanagement']['AC']['System Sleep Timer']`  
+* `node['cpe_powermanagement']['ACPower']['System Sleep Timer']`  
 Put system to sleep after this idle time  
 **Values**: Integer, number of minutes  
-* `node['cpe_powermanagement']['AC']['Wake On LAN']`  
+* `node['cpe_powermanagement']['ACPower']['Wake On LAN']`  
 Wake for a magic network packet  
 **Values**: true/false  
-* `node['cpe_powermanagement']['AC']['RestartAfterKernelPanic']`  
+* `node['cpe_powermanagement']['ACPower']['RestartAfterKernelPanic']`  
 Automatically restart after a kernel panic / freeze  
 **Values**: true/false  
 
@@ -72,7 +72,7 @@ etc.
 
 To set values for these keys, override the setting in your recipe:
 
-    node.default['cpe_powermanagement']['AC']['System Sleep Timer'] = 60
+    node.default['cpe_powermanagement']['ACPower']['System Sleep Timer'] = 60
 
 Example for how to set a series of these settings at once, in a recipe:
 

--- a/chef/cookbooks/cpe_powermanagement/README.md
+++ b/chef/cookbooks/cpe_powermanagement/README.md
@@ -30,7 +30,7 @@ Attributes
 
 Usage
 -----
-There are two sets of attributes that are identical - 'AC' for when on AC power (plugged in), and 'Battery' for when on battery.
+There are two sets of attributes that are identical - 'ACPower' for when on AC power (plugged in), and 'Battery' for when on battery.
 
 'Battery' settings will have no effect on desktops (and will not be applied by this recipe).
 


### PR DESCRIPTION
The readme for `cpe_powermanagement` references two different keys for the 'plugged in' power state. This PR replaces all references to the invalid key `AC` with the correct `ACPower` key.

CLA has been completed.