### PR TITLE
cpe_adobe_flash: +3x "Jitter"-related options

### DIFF
--- a/chef/cookbooks/cpe_adobe_flash/README.md
+++ b/chef/cookbooks/cpe_adobe_flash/README.md
@@ -49,7 +49,9 @@ Attributes
 * node['cpe_adobe_flash']['configs']['NetworkRequestTimeout']
 * node['cpe_adobe_flash']['configs']['EnableInsecureJunctionBehavior']
 * node['cpe_adobe_flash']['configs']['EnableLocalAppData']
-* node['cpe_adobe_flash']['configs']['DefaultLanguage']
+* node['cpe_adobe_flash']['configs']['EventJitterMicroseconds']
+* node['cpe_adobe_flash']['configs']['TimerJitterMicroseconds']
+* node['cpe_adobe_flash']['configs']['InsecureJitterDisabledDomain']
 
 Usage
 -----

--- a/chef/cookbooks/cpe_adobe_flash/attributes/default.rb
+++ b/chef/cookbooks/cpe_adobe_flash/attributes/default.rb
@@ -57,4 +57,7 @@ default['cpe_adobe_flash']['configs'] = {
   'EnableInsecureJunctionBehavior' => nil,
   'EnableLocalAppData' => nil,
   'DefaultLanguage' => nil,
+  'EventJitterMicroseconds' => nil,
+  'TimerJitterMicroseconds' => nil,
+  'InsecureJitterDisabledDomain' => nil,
 }


### PR DESCRIPTION
This PR, if merged, will append three new configurable options to the cookbook (`EventJitterMicroseconds`, `TimerJitterMicroseconds`, `InsecureJitterDisabledDomain`). These options are relating to mitigation of the Spectre/Meltdown CVE's (and other similar attack styles).

The documentation for these options can be found in the Adobe Flash Player Administration Guide [1] on pages 43 and 44.

[1] https://www.adobe.com/content/dam/acom/en/devnet/flashplayer/articles/flash_player_admin_guide/pdf/flash_player_32_0_admin_guide.pdf#G7.3058663