### PR TITLE
Fix prior README typo; +5 F.C. rule exclusions

### DIFF
--- a/chef/cookbooks/cpe_adobe_flash/README.md
+++ b/chef/cookbooks/cpe_adobe_flash/README.md
@@ -49,6 +49,7 @@ Attributes
 * node['cpe_adobe_flash']['configs']['NetworkRequestTimeout']
 * node['cpe_adobe_flash']['configs']['EnableInsecureJunctionBehavior']
 * node['cpe_adobe_flash']['configs']['EnableLocalAppData']
+* node['cpe_adobe_flash']['configs']['DefaultLanguage']
 * node['cpe_adobe_flash']['configs']['EventJitterMicroseconds']
 * node['cpe_adobe_flash']['configs']['TimerJitterMicroseconds']
 * node['cpe_adobe_flash']['configs']['InsecureJitterDisabledDomain']

--- a/tests/run_foodcritic.rb
+++ b/tests/run_foodcritic.rb
@@ -9,6 +9,11 @@ RSpec.describe 'Check that the cookbooks changed pass foodcritic.' do
       FC059
       FC064
       FC065
+      FC066
+      FC067
+      FC069
+      FC071
+      FC078
     ]
     @exclude_rules = @exclude_rules.join(' -t ~')
 


### PR DESCRIPTION
1. Commit (e38ea88) in this PR fixes bad commit (6113420) from PR #205 whereby I erroneously removed a line from `README.md`.

2.  Additionally, I noticed today that PR #205 had actually [failed its Travis tests](https://travis-ci.org/facebook/IT-CPE/builds/506490205?utm_source=github_status&utm_medium=notification) for violating 5 distinct rules:

```
FC066: Ensure chef_version is set in metadata: chef/cookbooks/cpe_adobe_flash/metadata.rb:1
FC067: Ensure at least one platform supported in metadata: chef/cookbooks/cpe_adobe_flash/metadata.rb:1
FC069: Ensure standardized license defined in metadata: chef/cookbooks/cpe_adobe_flash/metadata.rb:1
FC071: Missing LICENSE file: chef/cookbooks/cpe_adobe_flash/LICENSE:1
FC078: Ensure cookbook shared under an OSI-approved open source license: chef/cookbooks/cpe_adobe_flash/metadata.rb:1
```

FC066, FC067 - These two rules do not seem to reflect the Facebook CPE team's way of composing cookbooks. I say this as not a single cookbook contains a `metadata.rb` file with `chef_version` or `platform` defined. By negating these two rules, we can begin to Make CI Great Again, and turn those ❌ 's to ✅ 's. 

FC069, FC071, FC078 => All relating to the lack of licensing details _in the cookbook._ Seems to me that "the Facebook Way" ™️ is to put the `LICENSE` file at the root of the repo, and then reference said file where desired. Assuming that is true, I propose these three rules be added to the excluded rules during testing.

Furthermore, looking back at the past dozen Chef-related PR's which have been closed, they all have fell victim to at least one of these five rules above. That said, I think its safe to say these rules violations are ostensibly bogus, and non-deterministic of code quality, and therefore should be cast away from `run_foodcritic.rb`.