### PR TITLE
Make node serial cross platform, thanks to nmcspadden for windows method

### DIFF
--- a/chef/cookbooks/cpe_utils/libraries/node_functions.rb
+++ b/chef/cookbooks/cpe_utils/libraries/node_functions.rb
@@ -155,7 +155,8 @@ EOF
           )
           serial = nil
         end
-      serial
+        serial
+      end
     rescue StandardError => e
       Chef::Log.warn("Unable to get serial: #{e}")
       nil


### PR DESCRIPTION
This makes `node.serial` cross platform for macOS, Windows and Debian based OSes. We don't have anything redhat/fedora, but I'd love to see an implementation there too :) 

Thanks to @nmcspadden for the windows method here. It offers better support across multiple machine types.