### PR TITLE
Bring-in new node_function check for Ubuntu 18

### DIFF
--- a/chef/cookbooks/cpe_utils/README.md
+++ b/chef/cookbooks/cpe_utils/README.md
@@ -62,6 +62,7 @@ node.ubuntu?
 node.ubuntu14?
 node.ubuntu15?
 node.ubuntu16?
+node.ubuntu18?
 node.windows?
 node.windows8?
 node.windows8_1?

--- a/chef/cookbooks/cpe_utils/libraries/node_functions.rb
+++ b/chef/cookbooks/cpe_utils/libraries/node_functions.rb
@@ -396,6 +396,10 @@ class Chef
       self.ubuntu? && node['platform_version'].start_with?('16.')
     end
 
+    def ubuntu18?
+      self.ubuntu? && node['platform_version'].start_with?('18.')
+    end
+    
     def fedora27?
       self.fedora? && node['platform_version'].eql?('27')
     end


### PR DESCRIPTION
This PR, if merged, will bring in a new method (`ubuntu18?`) to `cpe_utils/libraries/node_functions.rb` which checks if a given node is running Ubuntu 18.x.y.z (also known as, "Da Bio-Beav", also also known as "Bionic Beaver").

Additionally, this PR will add the requisite documentation (in `cpe_utils/README.md`) for the aforementioned new node function.

![image](https://user-images.githubusercontent.com/24925402/59660189-2f8fd780-91a8-11e9-8f7a-cac36bda5a56.png)
