### PR TITLE
cpe_utils README.md updates & add def ubuntu18?

### DIFF
--- a/chef/cookbooks/cpe_utils/README.md
+++ b/chef/cookbooks/cpe_utils/README.md
@@ -4,10 +4,209 @@ This cookbook is where we keep all the common function / classes
 
 Usage
 -----
+#### node.app_installed? ####
+Returns a boolean value stating whether or osquery detects that a given application (defined by the application's name) is installed.
 
+```
+if node.app_installed?('com.apple.Pages')
+  do_thing
+else
+  do_other_thing
+end
+```
+
+#### node.installed? ####
+Same concept as `node.app_installed?`, but only available for macOS (leverages `app_paths_deprecated` and, subsequently, `app_paths_deprecated`); application is defined by the application's bundle identifier (_not_ app name, as is the case with `app_installed`).
+
+```
+if node.installed?('firefox')
+  do_thing
+else
+  do_other_thing
+end
+```
+
+#### node.app_paths ####
+Cross-platform function utilizing osquery to return the path(s) to an installation of a given application.
+
+```
+node.app_paths('firefox').each do |app_path|
+  "Firefox installation located at #{app_path}"
+end
+```
+
+#### node.app_paths_deprecated ####
+Same concept as `node.app_paths`, but only available for macOS (leverages `mdfind`; Spotlight)
+
+```
+node.app_paths_deprecated('firefox').each do |app_path|
+  "Firefox installation located at #{app_path}"
+end
+```
+
+#### node.mac_bundleid_installed? ####
+Returns a boolean evaluation, via osquery, for the existence of a provided bundle identifier.
+
+```
+if node.mac_bundleid_installed?('com.apple.Pages')
+  node.munki_installed?('Pages')
+end
+```
+
+#### node.loginwindow? ####
+Returns `true` if the device is sitting at the login window.
+
+```
+osx_profile 'Install some user profile' do
+  only_if { !node.loginwindow? }
+  profile 'com.company.someuserprofile.mobileconfig'
+end
+```
+
+#### node.macos_mdm_state ####
+Returns either `nil` (not enrolled in MDM) or a string value denoting the state of MDM on the device (i.e. `mdm`, `uamdm`, or `dep`).
+
+```
+if node.macos_mdm_state.nil?
+  include_recipe 'cpe_umad::default'
+else
+  Chef::Log.debug("#{node.macos_mdm_state}")
+end
+```
+
+#### node.dep? ####
+Returns `true` if the device is enrolled into MDM via DEP.
+
+```
+if node.dep? do
+  something
+end  
+```
+
+#### node.uamdm? ####
+Returns `true` if the device is enrolled into MDM with user-approval.
+
+```
+if node.uamdm? do
+  something
+end  
+```
+
+#### node.mdm? ####
+Returns `true` if the device is enrolled into MDM (via any methodology).
+
+```
+if node.mdm? do
+  something
+end  
+```
+
+#### node.windows_supports_long_paths? ####
+Returns `true` when Windows build is greater than `10.0.14393` and, therefore, supports long paths.
+
+```
+if node.windows_supports_long_paths?
+  do_thing
+else
+  do_other_thing
+end
+```
+
+#### node.sysnative_path ####
+Returns a string value containing the proper path to the `System32` directory.
+
+```
+if node.windows?
+  Dir["#{node.sysnative_path}*"].each do |system32_item|
+    system32_item
+  end
+end
+```
+
+#### node.uuid ####
+Returns a string of the device's UUID (as determined by `system_profiler`'s `SPHardwareDataType`).
+
+```
+"UUID has changed!" if node.uuid != node['first_run']['attributes']['uuid']
+```
+
+#### node.warn_to_remove ####
+Appends a warning entry to Chef log if the node function dictates that sharding cleanup is needed.
+
+```
+warn_to_remove(3) if Time.now.tv_sec > Time.parse(start_time).tv_sec + 100
+```
+
+#### node.serial ####
+Returns a string of the macOS device's serial number (as determined by `ioreg`).
+
+```
+if node.serial.start_with?('RM')
+  node['refurbished'] == true
+else  
+  node['refurbished'] == false
+end
+```
+
+#### node.console_user ####
+Returns a string value of the user with a current console session, and memoizes the value for performance of recurrent use.
+
+```
+launchd 'com.company.internaltool.launchagent' do
+  label 'com.company.internaltool.launchagent'
+  run_at_load true
+  type 'agent'
+  action :enable
+  only_if { node.console_user != 'root' }
+end
+```
+
+#### node.loginctl_users ####
+On Linux, returns a hash of currently logged in user (format: `{ 'uid' => Integer(uid), 'username' => uname }`).
+
+```
+if node.loginctl_users['username'] == 'root'
+  "Current console session is root"
+else
+  "Current console session is not root"
+end
+```
+
+#### node.attr_lookup ####
+Allows you to dig through the node's attributes but still get back an arbitrary value in the event the key does not exist.
+
+```
+if node.attr_lookup('ohai/some_custom_plugin/some_custom_plugin_attribute')
+  do_thing
+else
+  do_other_thing
+end
+```
+
+#### node.in_shard? ####
+Evaluates whether or not a node is within (read: less-than or equal-to) a passed sharding threshold.
+
+```
+remote_pkg 'ChefDK' do
+  only_if { node.in_shard?(50) }
+  version '3.11.3-1'
+  checksum '7dfc54c290a0f5d889a50dbe292eb5b862e99ed6826fae5882ed29a93c2c5a17'
+  receipt 'com.getchef.pkg.chefdk'
+end
+```
+
+#### node.get_shard ####
+Using the device's serial (preferred for Darwin/Linux) or `system_uuid` (preferred for Windows), calculate and return an integer representing the shard (1-100) in which the node exists.
+
+```
+if node.get_shard == 42
+  'This is a bad example'
+end
+```
 
 #### node.os_greater_than? ####
 If the current system's OS X version is greater than the specified version, do something.
+
 ```
 if node.os_greater_than?('10.10') do
   something
@@ -15,7 +214,7 @@ end
 ```
 
 #### node.os_less_than? ####
-If the current system's OS X version is less than the specified version, do something.
+If the current system's macOS version is less than the specified version, do something.
 
 ```
 if node.os_less_than?('10.11') do
@@ -25,6 +224,7 @@ end
 
 #### node.os_at_least? ####
 This functions like a greater than or equal to. In this example, if the machine is 10.11.1 or greater, it will run something.
+
 ```
 if node.os_at_least?('10.11.1') do
   something
@@ -33,6 +233,7 @@ end
 
 #### node.os_at_least_or_lower? ####
 This functions like a less than or equal to. In this example, if the machine is 10.10.3 or lower, it will run something.
+
 ```
 if node.os_at_least_or_lower?('10.10.3') do
   something
@@ -40,7 +241,6 @@ end
 ```
 
 #### OS Checks ####
-
 These are to check if a node is a specific OS family, type, or version.
 
 ```
@@ -62,6 +262,7 @@ node.ubuntu?
 node.ubuntu14?
 node.ubuntu15?
 node.ubuntu16?
+node.ubuntu18?
 node.windows?
 node.windows8?
 node.windows8_1?
@@ -74,7 +275,7 @@ These are generally used to scope os-specific features. For instance:
 
 ```
 if node.macos?
-  osx_profile 'com.company.screensaver.mobileconfig' 
+  osx_profile 'com.company.screensaver.mobileconfig'
 end
 ```
 
@@ -83,6 +284,18 @@ These can also be used within a resource block via only_if
 osx_profile 'Install screensaver profile' do
   only_if { node.macos? }
   profile 'com.company.screensaver.mobileconfig'
+end
+```
+
+#### node.virtual_macos_type ####
+Determines whether the node is a virtualized instance of macOS and, if so, returns a string value of the virtualization providers employed (`vmware`, `virtualbox`, `parallels`). If the node is not virtualized, `physical` will be returned.
+
+```
+remote_pkg 'VMWareTools' do
+  only_if { node.virtual_macos_type == 'vmware' }
+  version '1.1.0'
+  checksum '3701fbdc8096756fab077387536535b237e010c45147ea631f7df43e3e4904e0'
+  receipt 'com.vmware.tools'
 end
 ```
 
@@ -164,6 +377,7 @@ end
 
 #### node.munki_installed? ####
 Returns true if the item is in munki's managed_installs list.
+
 ```
 if node.munki_installed?('Firefox') do
   something

--- a/chef/cookbooks/cpe_utils/libraries/node_functions.rb
+++ b/chef/cookbooks/cpe_utils/libraries/node_functions.rb
@@ -101,7 +101,7 @@ class Chef
 
     def serial
       unless macos?
-        Chef::Log.warn('node.serial called on non-OS X!')
+        Chef::Log.warn('node.serial called on non-macOS!')
         return
       end
       return node['serial'] if node['serial']
@@ -115,7 +115,7 @@ class Chef
 
     def uuid
       unless macos?
-        Chef::Log.warn('node.serial called on non-OS X!')
+        Chef::Log.warn('node.uuid called on non-macOS!')
         return
       end
       return node['uuid'] if node['uuid']
@@ -396,6 +396,10 @@ class Chef
       self.ubuntu? && node['platform_version'].start_with?('16.')
     end
 
+    def ubuntu18?
+      self.ubuntu? && node['platform_version'].start_with?('18.')
+    end
+
     def fedora27?
       self.fedora? && node['platform_version'].eql?('27')
     end
@@ -641,7 +645,7 @@ class Chef
 
     def app_paths_deprecated(bundle_identifier)
       unless macos?
-        Chef::Log.warn('node.app_paths_deprecated called on non-OS X!')
+        Chef::Log.warn('node.app_paths_deprecated called on non-macOS!')
         []
       end
       # Search Spotlight for matching identifier, strip newlines
@@ -652,7 +656,7 @@ class Chef
 
     def installed?(bundle_identifier)
       unless macos?
-        Chef::Log.warn('node.installed? called on non-OS X!')
+        Chef::Log.warn('node.installed? called on non-macOS!')
         false
       end
       paths = app_paths_deprecated(bundle_identifier)
@@ -692,7 +696,7 @@ class Chef
 
     def min_package_installed?(pkg_identifier, min_pkg)
       unless macos?
-        Chef::Log.warn('node.min_package_installed? called on non-OS X!')
+        Chef::Log.warn('node.min_package_installed? called on non-macOS!')
         false
       end
       installed_pkg_version = shell_out(
@@ -708,7 +712,7 @@ class Chef
 
     def max_package_installed?(pkg_identifier, max_pkg)
       unless macos?
-        Chef::Log.warn('node.max_package_installed? called on non-OS X!')
+        Chef::Log.warn('node.max_package_installed? called on non-macOS!')
         false
       end
       installed_pkg_version = shell_out(


### PR DESCRIPTION
This PR, if merged, will bring in a new method (ubuntu18?) to cpe_utils/libraries/node_functions.rb which checks if a given node is running Ubuntu 18.x.y.z (also known as, "Da Bio-Beav", also also known as "Bionic Beaver").

Additionally, this PR will extend `README.md` to include all functions defined in `node_functions.rb`.

The only other change made is modifying lingering instances of `Chef::Log.warn('node.serial called on non-OS X!')`to reflect `Chef::Log.warn('node.serial called on non-macOS!')`. Previously, there was an inconsistency whereby some of the `Chef::Log.warn` calls were stating `non-macOS` while other instances logged `non-OS X`. Now, with this PR, they will all reflect `non-macOS` which will make it a tad easier to grep client logs for such warnings (and we can make our good friends Craig Federighi and Tim Apple happy).

🤙 