### PR TITLE
Adding copyright header to cpe_helpers metadata

### DIFF
--- a/itchef/cookbooks/cpe_hosts/metadata.rb
+++ b/itchef/cookbooks/cpe_hosts/metadata.rb
@@ -1,5 +1,4 @@
-# vim: syntax=ruby:expandtab:shiftwidth=2:softtabstop=2:tabstop=2
-
+# Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
 name 'cpe_hosts'
 maintainer 'Facebook'
 maintainer_email 'noreply@facebook.com'


### PR DESCRIPTION
The copyright header was not added when cpe_helpers got checked in.