### PR TITLE
makes version/action guard functional

### DIFF
--- a/chef/cookbooks/cpe_choco/resources/cpe_choco_apps.rb
+++ b/chef/cookbooks/cpe_choco/resources/cpe_choco_apps.rb
@@ -94,15 +94,17 @@ action_class do
   def action_guard(option)
     if option['version'].casecmp('latest').zero?
       :upgrade
+    else
+      :install
     end
-    :install
   end
 
   def version_guard(option)
     if option['version'].casecmp('latest').zero?
       nil
+    else
+      option['version']
     end
-    option['version']
   end
 
   def process_lists


### PR DESCRIPTION
As written, these guards will always return the original value. Was rather confused that "latest" was not being respected - indeed being passed literal - during our testing.