### PR TITLE
add allow_downgrade properties for cpe_remote_pkg

### DIFF
--- a/chef/cookbooks/cpe_remote/README.md
+++ b/chef/cookbooks/cpe_remote/README.md
@@ -38,6 +38,8 @@ This resource will install a Apple package (`.pkg` file). It will retrieve the p
 - :install - Install the package.
 
 #### Parameter attributes:
+- `allow_downgrade` - BOOL - Downgrade a package to satisfy requested version
+          requirements.
 - `app` - [name] This is the name of the app that the pkg will be installing,
           and the location of the pkg on the server: `base_url/app/app-version.pkg`
 - `checksum` - sha256 checksum of the pkg to download.

--- a/chef/cookbooks/cpe_remote/resources/pkg.rb
+++ b/chef/cookbooks/cpe_remote/resources/pkg.rb
@@ -21,6 +21,7 @@ resource_name :cpe_remote_pkg
 default_action :install
 
 provides :cpe_remote_pkg, :os => 'darwin'
+property :allow_downgrade, [TrueClass, FalseClass], :default => true
 property :app, String, :name_property => true
 property :checksum, String
 property :backup, [FalseClass, Integer], :default => false
@@ -33,6 +34,16 @@ property :version, String
 
 action_class do
   include CPE::Remote
+  def log_info(msg)
+    CPE::Log.log(
+      msg,
+      :level => :info,
+      :type => 'cpe_remote_pkg',
+      :action => 'install',
+      :status => 'success',
+    )
+  end
+
   def log_warn(msg)
     CPE::Log.log(
       msg,
@@ -55,13 +66,27 @@ load_current_value do
   version shell_out(cmd).stdout.to_s[/version: (.*)/, 1]
 end
 
-action :install do
+action :install do # rubocop:disable Metrics/BlockLength
   return unless log_unless(
     'Distro server inaccessible',
   ) { node['cpe_remote']['server_accessible'] }
+
+  desired_pkg_version = new_resource.version
+  installed_pkg_version = current_resource.version
+
+  unless new_resource.allow_downgrade
+    if Gem::Version.new(installed_pkg_version) > Gem::Version.new(desired_pkg_version) # rubocop:disable Metrics/LineLength
+      log_info(
+        "Installed version (#{installed_pkg_version}) is higher than desired "\
+        "version (#{desired_pkg_version}), but allow_downgrade is false.",
+      )
+      return
+    end
+  end
+
   converge_if_changed :version do
     pkg_name = new_resource.app
-    pkg_version_str = "-#{new_resource.version}"
+    pkg_version_str = "-#{pkg_version}"
     if new_resource.pkg_name
       pkg_name = new_resource.pkg_name
       pkg_version_str = ''

--- a/chef/cookbooks/cpe_remote/resources/pkg.rb
+++ b/chef/cookbooks/cpe_remote/resources/pkg.rb
@@ -71,14 +71,14 @@ action :install do # rubocop:disable Metrics/BlockLength
     'Distro server inaccessible',
   ) { node['cpe_remote']['server_accessible'] }
 
-  desired_pkg_version = new_resource.version
-  installed_pkg_version = current_resource.version
+  desired_version = new_resource.version
+  installed_version = current_resource.version
 
   unless new_resource.allow_downgrade
-    if Gem::Version.new(installed_pkg_version) > Gem::Version.new(desired_pkg_version) # rubocop:disable Metrics/LineLength
+    if Gem::Version.new(installed_version) > Gem::Version.new(desired_version)
       log_info(
-        "Installed version (#{installed_pkg_version}) is higher than desired "\
-        "version (#{desired_pkg_version}), but allow_downgrade is false.",
+        "Installed version (#{installed_version}) is higher than desired "\
+        "version (#{desired_version}), but allow_downgrade is false.",
       )
       return
     end
@@ -86,7 +86,7 @@ action :install do # rubocop:disable Metrics/BlockLength
 
   converge_if_changed :version do
     pkg_name = new_resource.app
-    pkg_version_str = "-#{pkg_version}"
+    pkg_version_str = "-#{desired_version}"
     if new_resource.pkg_name
       pkg_name = new_resource.pkg_name
       pkg_version_str = ''


### PR DESCRIPTION
This allows an admin to not force downgrades.

This follows https://github.com/chef/chef/blob/master/lib/chef/provider/package.rb per @mikedodge04 

```
cpe_remote_pkg 'osqueryd' do
  allow_downgrade false
  version '1.1.0'
  checksum '3701fbdc8096756fab077387536535b237e010c45147ea631f7df43e3e4904e0'
  receipt 'com.facebook.osqueryd'
end
```

By default, it will be `true`. This keeps the default behavior of the native package resource, while also following the current behavior of cpe_remote_pkg.