### PR TITLE
Various cookstyle fixes

### DIFF
--- a/itchef/cookbooks/cpe_adobe_flash/metadata.rb
+++ b/itchef/cookbooks/cpe_adobe_flash/metadata.rb
@@ -5,7 +5,6 @@ maintainer 'Facebook'
 maintainer_email 'noreply@facebook.com'
 license 'Apache-2.0'
 description 'Ensure flash configuration settings'
-long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
 version '0.1.0'
 
 depends 'cpe_helpers'

--- a/itchef/cookbooks/cpe_adobe_flash/resources/configure_adobe_flash_darwin.rb
+++ b/itchef/cookbooks/cpe_adobe_flash/resources/configure_adobe_flash_darwin.rb
@@ -47,14 +47,14 @@ action_class do
       not_if { configs.empty? }
       owner 'root'
       group 'admin'
-      mode 0755
+      mode '755'
       action :create
     end
     template ::File.join(config_dir, 'mms.cfg') do # ~ FB016
       source 'cpe_adobe_flash.erb'
       owner 'root'
       group 'admin'
-      mode 0644
+      mode '644'
       action configs.empty? ? :delete : :create
       notifies :restart, 'launchd[com.adobe.fpsaud]'
     end

--- a/itchef/cookbooks/cpe_applocker/metadata.rb
+++ b/itchef/cookbooks/cpe_applocker/metadata.rb
@@ -5,6 +5,5 @@ maintainer_email 'noreply@fb.com'
 license 'Apache-2.0'
 description 'Installs and configures Applocker for Windows.'
 version '0.1.0'
-long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
 
 depends 'cpe_helpers'

--- a/itchef/cookbooks/cpe_bluetooth/metadata.rb
+++ b/itchef/cookbooks/cpe_bluetooth/metadata.rb
@@ -5,7 +5,6 @@ maintainer 'Facebook'
 maintainer_email 'noreply@facebook.com'
 license 'Apache-2.0'
 description 'Manages Bluetooth settings / profile'
-long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
 version '0.1.0'
 supports 'mac_os_x'
 

--- a/itchef/cookbooks/cpe_chrome/metadata.rb
+++ b/itchef/cookbooks/cpe_chrome/metadata.rb
@@ -5,7 +5,6 @@ maintainer 'Facebook'
 maintainer_email 'noreply@facebook.com'
 license 'Apache-2.0'
 description 'Manage and configure Chrome browser'
-long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
 version '0.1.0'
 
 depends 'cpe_profiles'

--- a/itchef/cookbooks/cpe_dconf/metadata.rb
+++ b/itchef/cookbooks/cpe_dconf/metadata.rb
@@ -5,6 +5,5 @@ maintainer_email 'noreply@facebook.com'
 license 'Apache-2.0'
 description 'Manage dconf settings'
 source_url 'https://github.com/facebook/IT-CPE/tree/master/itchef/'
-long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
 version '0.1.0'
 depends 'fb_helpers'

--- a/itchef/cookbooks/cpe_deprecation_notifier/metadata.rb
+++ b/itchef/cookbooks/cpe_deprecation_notifier/metadata.rb
@@ -4,7 +4,6 @@ maintainer 'IT-CPE'
 maintainer_email 'noreply@facebook.com'
 license 'Apache-2.0'
 description 'Installs and configures deprecation notifier'
-long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
 version '0.1.0'
 
 depends 'cpe_logger'

--- a/itchef/cookbooks/cpe_flatpak/metadata.rb
+++ b/itchef/cookbooks/cpe_flatpak/metadata.rb
@@ -4,7 +4,6 @@ maintainer 'Facebook'
 maintainer_email 'noreply@fb.com'
 license 'Apache-2.0'
 description 'Manage Flatpak'
-long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
 version '0.0.1'
 
 depends 'cpe_helpers'

--- a/itchef/cookbooks/cpe_flatpak/resources/flatpak.rb
+++ b/itchef/cookbooks/cpe_flatpak/resources/flatpak.rb
@@ -71,7 +71,7 @@ action :manage do
 
   cache_dir = "#{chef_cache}/cpe_flatpak"
   directory cache_dir do
-    mode 0755
+    mode '755'
     owner 'root'
     group 'root'
   end

--- a/itchef/cookbooks/cpe_gnome_software/metadata.rb
+++ b/itchef/cookbooks/cpe_gnome_software/metadata.rb
@@ -4,7 +4,6 @@ maintainer 'Facebook'
 maintainer_email 'noreply@facebook.com'
 license 'Apache-2.0'
 description 'Configures GNOME Software and PackageKit'
-long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
 version '0.1.0'
 
 depends 'cpe_helpers'

--- a/itchef/cookbooks/cpe_helpers/metadata.rb
+++ b/itchef/cookbooks/cpe_helpers/metadata.rb
@@ -5,7 +5,6 @@ maintainer_email 'noreply@facebook.com'
 license 'Apache-2.0'
 description 'Helper methods for Facebook IT-CPE open-source cookbooks'
 source_url 'https://github.com/facebook/IT-CPE/tree/master/itchef/'
-long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
 version '0.1.0'
 
 supports 'fedora'

--- a/itchef/cookbooks/cpe_hosts/metadata.rb
+++ b/itchef/cookbooks/cpe_hosts/metadata.rb
@@ -5,7 +5,6 @@ maintainer_email 'noreply@facebook.com'
 license 'Apache-2.0'
 description 'Manages the entries in the /etc/hosts file'
 source_url 'https://github.com/facebook/IT-CPE/tree/master/itchef/'
-long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
 version '0.2.0'
 supports 'fedora'
 supports 'ubuntu'

--- a/itchef/cookbooks/cpe_init/metadata.rb
+++ b/itchef/cookbooks/cpe_init/metadata.rb
@@ -4,7 +4,6 @@ maintainer 'Facebook'
 maintainer_email 'noreply@facebook.com'
 license 'Apache-2.0'
 description 'This is the very basic cookbook that starts it all.'
-long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
 version '0.1.0'
 
 # Multi-platform

--- a/itchef/cookbooks/cpe_kernel_channel/metadata.rb
+++ b/itchef/cookbooks/cpe_kernel_channel/metadata.rb
@@ -5,6 +5,5 @@ maintainer_email 'noreply@facebook.com'
 license 'Apache-2.0'
 description 'Configures the repo used to deliver kernel packages'
 source_url 'https://github.com/facebook/IT-CPE/tree/master/itchef/'
-long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
 version '0.1.0'
 depends 'fb_helpers'

--- a/itchef/cookbooks/cpe_launchd/metadata.rb
+++ b/itchef/cookbooks/cpe_launchd/metadata.rb
@@ -4,7 +4,6 @@ maintainer 'Facebook'
 maintainer_email 'noreply@facebook.com'
 license 'Apache-2.0'
 description 'Installs/Configures cpe_launchd'
-long_description 'Installs/Configures cpe_launchd'
 version '0.1.0'
 supports 'mac_os_x'
 

--- a/itchef/cookbooks/cpe_logger/metadata.rb
+++ b/itchef/cookbooks/cpe_logger/metadata.rb
@@ -4,7 +4,6 @@ maintainer 'Facebook_IT-CPE'
 maintainer_email 'noreply@facebook.com'
 license 'Apache-2.0'
 description 'This cookbook if for logging tools'
-long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
 version '0.1.0'
 
 depends 'cpe_helpers'

--- a/itchef/cookbooks/cpe_munki/metadata.rb
+++ b/itchef/cookbooks/cpe_munki/metadata.rb
@@ -5,7 +5,6 @@ maintainer 'Facebook'
 maintainer_email 'noreply@facebook.com'
 license 'Apache-2.0'
 description 'Installs/Configures Munki'
-long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
 version '0.3.0'
 
 depends 'cpe_remote'

--- a/itchef/cookbooks/cpe_node_customizations/metadata.rb
+++ b/itchef/cookbooks/cpe_node_customizations/metadata.rb
@@ -4,5 +4,4 @@ maintainer 'Facebook'
 maintainer_email 'noreply@facebook.com'
 license 'Apache-2.0'
 description 'This cookbook holds recipes each person creates for themselves.'
-long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
 version '0.0.1'

--- a/itchef/cookbooks/cpe_node_customizations/recipes/default.rb
+++ b/itchef/cookbooks/cpe_node_customizations/recipes/default.rb
@@ -23,6 +23,6 @@ rescue Exception => e
   Chef::Log.warn(
     "Error in cpe_node_customizations::#{node.name} \n" +
     "#{e.message} \n" +
-    "#{e.backtrace.inspect} \n"
+    "#{e.backtrace.inspect} \n",
   )
 end

--- a/itchef/cookbooks/cpe_nomad/metadata.rb
+++ b/itchef/cookbooks/cpe_nomad/metadata.rb
@@ -4,7 +4,6 @@ maintainer 'Facebook'
 maintainer_email 'noreply@fb.com'
 license 'Apache-2.0'
 description 'Installs/configures NoMAD'
-long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
 version '0.1.0'
 
 depends 'fb_launchd'

--- a/itchef/cookbooks/cpe_pathsd/metadata.rb
+++ b/itchef/cookbooks/cpe_pathsd/metadata.rb
@@ -4,7 +4,6 @@ maintainer 'Facebook'
 maintainer_email 'noreply@facebook.com'
 license 'Apache-2.0'
 description 'Installs/Configures cpe_pathsd'
-long_description 'Installs/Configures cpe_pathsd'
 version '0.1.0'
 
 supports 'fedora'

--- a/itchef/cookbooks/cpe_pathsd/resources/cpe_pathsd_darwin.rb
+++ b/itchef/cookbooks/cpe_pathsd/resources/cpe_pathsd_darwin.rb
@@ -23,13 +23,13 @@ action :manage do
   directory '/etc/paths.d/' do
     owner 'root'
     group 'wheel'
-    mode 0755
+    mode '755'
   end
 
   template '/etc/paths.d/cpe_pathsd' do
     source 'cpe_pathsd'
     owner 'root'
     group 'wheel'
-    mode 0644
+    mode '644'
   end
 end

--- a/itchef/cookbooks/cpe_powermanagement/metadata.rb
+++ b/itchef/cookbooks/cpe_powermanagement/metadata.rb
@@ -4,7 +4,6 @@ maintainer 'Facebook'
 maintainer_email 'noreply@facebook.com'
 license 'Apache-2.0'
 description 'Manages powermanagement settings / profile'
-long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
 version '0.1.0'
 supports 'mac_os_x'
 

--- a/itchef/cookbooks/cpe_preferencepanes/metadata.rb
+++ b/itchef/cookbooks/cpe_preferencepanes/metadata.rb
@@ -4,7 +4,6 @@ maintainer 'Facebook'
 maintainer_email 'noreply@facebook.com'
 license 'Apache-2.0'
 description 'Installs/Configures cpe_preferencepanes'
-long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
 version '0.1.0'
 supports 'mac_os_x'
 

--- a/itchef/cookbooks/cpe_profiles/metadata.rb
+++ b/itchef/cookbooks/cpe_profiles/metadata.rb
@@ -4,7 +4,6 @@ maintainer 'Facebook'
 maintainer_email 'noreply@facebook.com'
 license 'Apache-2.0'
 description 'Manages macOS configuration profiles via other cookbooks'
-long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
 version '0.1.0'
 supports 'mac_os_x'
 

--- a/itchef/cookbooks/cpe_profiles_local/metadata.rb
+++ b/itchef/cookbooks/cpe_profiles_local/metadata.rb
@@ -4,7 +4,6 @@ maintainer 'Facebook'
 maintainer_email 'noreply@facebook.com'
 license 'Apache-2.0'
 description 'Installs/configures macOS configuration profiles'
-long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
 version '0.1.0'
 supports 'mac_os_x'
 depends 'fb_helpers'

--- a/itchef/cookbooks/cpe_remote/metadata.rb
+++ b/itchef/cookbooks/cpe_remote/metadata.rb
@@ -4,7 +4,6 @@ maintainer 'Facebook'
 maintainer_email 'noreply@fb.com'
 license 'Apache-2.0'
 description 'cpe_remote_pkg and cpe_remote_file '
-long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
 version '0.1'
 supports 'fedora'
 supports 'mac_os_x'

--- a/itchef/cookbooks/cpe_remote/resources/file.rb
+++ b/itchef/cookbooks/cpe_remote/resources/file.rb
@@ -23,7 +23,7 @@ provides :cpe_remote_file
 property :folder_name, String, :name_property => true
 # see https://github.com/chef/chef/blob/ +
 # f43371b231d7bb88c01618c90347cbb1fc96a393/lib/chef/resource/file.rb
-property :atomic_update, [TrueClass, FalseClass],
+property :atomic_update, [true, false],
          :default => lazy { Chef::Config[:file_atomic_update] },
          :desired_state => false
 property :checksum, String

--- a/itchef/cookbooks/cpe_remote/resources/pkg.rb
+++ b/itchef/cookbooks/cpe_remote/resources/pkg.rb
@@ -20,15 +20,15 @@ resource_name :cpe_remote_pkg
 default_action :install
 
 provides :cpe_remote_pkg, :os => 'darwin'
-property :allow_downgrade, [TrueClass, FalseClass], :default => true
+property :allow_downgrade, [true, false], :default => true
 property :app, String, :name_property => true
 property :checksum, String
 property :backup, [FalseClass, Integer], :default => false
-property :mpkg, [TrueClass, FalseClass], :default => false
+property :mpkg, [true, false], :default => false
 property :pkg_name, String
 property :pkg_url, String
 property :receipt, String, :desired_state => false
-property :remote, [TrueClass, FalseClass], :default => true
+property :remote, [true, false], :default => true
 property :version, String
 
 action_class do

--- a/itchef/cookbooks/cpe_remote/resources/zip.rb
+++ b/itchef/cookbooks/cpe_remote/resources/zip.rb
@@ -92,7 +92,7 @@ action :create do
         path new_resource.extract_location
         owner 'Administrators'
         group 'Administrators'
-        mode 0755
+        mode '755'
         action :nothing
       end
       # Decompress zip file via shell.

--- a/itchef/cookbooks/cpe_spotlight/metadata.rb
+++ b/itchef/cookbooks/cpe_spotlight/metadata.rb
@@ -4,7 +4,6 @@ maintainer 'Facebook'
 maintainer_email 'noreply@facebook.com'
 license 'Apache-2.0'
 description 'Manages Spotlight exclusions'
-long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
 version '0.1.0'
 
 depends 'cpe_helpers'

--- a/itchef/cookbooks/cpe_symlinks/metadata.rb
+++ b/itchef/cookbooks/cpe_symlinks/metadata.rb
@@ -4,7 +4,6 @@ maintainer        'Facebook, Inc.'
 maintainer_email  'noreply@facebook.com'
 license           'Apache-2.0'
 description       'Manages symlinks on the machine'
-long_description  IO.read(File.join(File.dirname(__FILE__), 'README.md'))
 version           '0.4.3'
 
 depends 'cpe_helpers'

--- a/itchef/cookbooks/cpe_user_customizations/metadata.rb
+++ b/itchef/cookbooks/cpe_user_customizations/metadata.rb
@@ -4,7 +4,6 @@ maintainer 'Facebook'
 maintainer_email 'noreply@facebook.com'
 license 'Apache-2.0'
 description 'This cookbook holds recipes each person creates for themselves.'
-long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
 version '0.0.1'
 
 depends 'cpe_helpers'

--- a/itchef/cookbooks/cpe_user_customizations/recipes/default.rb
+++ b/itchef/cookbooks/cpe_user_customizations/recipes/default.rb
@@ -25,6 +25,6 @@ rescue Exception => e
   Chef::Log.warn(
     "Error in cpe_user_customizations::#{user.downcase} \n"+
     "#{e.message} \n" +
-    "#{e.backtrace.inspect} \n"
+    "#{e.backtrace.inspect} \n",
   )
 end

--- a/itchef/cookbooks/cpe_vfuse/metadata.rb
+++ b/itchef/cookbooks/cpe_vfuse/metadata.rb
@@ -5,7 +5,6 @@ maintainer 'Facebook'
 maintainer_email 'noreply@fb.com'
 license 'Apache-2.0'
 description 'Installs vfuse'
-long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
 version '0.1.0'
 
 depends 'cpe_helpers'

--- a/itchef/cookbooks/cpe_win_telemetry/metadata.rb
+++ b/itchef/cookbooks/cpe_win_telemetry/metadata.rb
@@ -4,7 +4,6 @@ maintainer 'Facebook'
 maintainer_email 'noreply@facebook.com'
 license 'Apache-2.0'
 description 'Installs/Configures cpe_win_telemetry'
-long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
 version '0.1.0'
 
 depends 'cpe_helpers'

--- a/itchef/cookbooks/fb_helpers/metadata.rb
+++ b/itchef/cookbooks/fb_helpers/metadata.rb
@@ -5,7 +5,6 @@ maintainer_email 'noreply@facebook.com'
 license 'Apache-2.0'
 description 'Helper methods for Facebook open-source cookbooks'
 source_url 'https://github.com/facebook/chef-cookbooks/'
-long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
 # never EVER change this number, ever.
 version '0.1.0'
 supports 'centos'

--- a/itchef/cookbooks/fb_launchd/metadata.rb
+++ b/itchef/cookbooks/fb_launchd/metadata.rb
@@ -5,7 +5,6 @@ maintainer_email 'noreply@facebook.com'
 license 'Apache-2.0'
 description 'Installs/Configures Chef-defined launchd plists'
 source_url 'https://github.com/facebook/chef-cookbooks/'
-long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
 version '0.1.0'
 supports 'mac_os_x'
 depends 'fb_helpers'

--- a/itchef/cookbooks/fb_launchd/resources/default.rb
+++ b/itchef/cookbooks/fb_launchd/resources/default.rb
@@ -20,10 +20,6 @@ provides :fb_launchd, :os => 'darwin'
 
 default_action :run
 
-def whyrun_supported?
-  true
-end
-
 # Attributes that circumvent or defeat the purpose of using launchd as a node
 # API. Blacklist them so that this blows up when they're used. If you really
 # want to use these, just make a launchd resource instead.


### PR DESCRIPTION
I scanned and autocorrected this repo with Cookstyle 5.10. Cookstyle now includes 100+ Chef specific cops that correct common mistakes and style we've seen in community cookbooks. I made one change per commit so it would be easier to understand what was being done and to cherry-pick if that's what you want to do.

I also removed the Foodcritic checking as this is pretty redundant at this point now that Cookstyle includes Chef linting. Additionally the linting in cookstyle is far less prone to false positives and focuses more on modern cookbook design practices.
-Tim