### PR TITLE
Don't manage /etc/paths inside cpe_pathsd

### DIFF
--- a/chef/cookbooks/cpe_pathsd/files/default/paths
+++ b/chef/cookbooks/cpe_pathsd/files/default/paths
@@ -1,5 +1,0 @@
-/usr/local/bin
-/usr/bin
-/bin
-/usr/sbin
-/sbin

--- a/chef/cookbooks/cpe_pathsd/recipes/darwin.rb
+++ b/chef/cookbooks/cpe_pathsd/recipes/darwin.rb
@@ -24,12 +24,3 @@ template '/etc/paths.d/cpe_pathsd' do
   group 'wheel'
   mode 0644
 end
-
-# No one should have the ability to update /etc/paths though an API.
-cookbook_file '/etc/paths' do
-  source 'paths'
-  owner root_owner
-  group root_group
-  mode 0644
-  action :create
-end

--- a/itchef/cookbooks/cpe_pathsd/files/default/paths
+++ b/itchef/cookbooks/cpe_pathsd/files/default/paths
@@ -1,6 +1,0 @@
-/opt/facebook/bin
-/usr/local/bin
-/usr/bin
-/bin
-/usr/sbin
-/sbin

--- a/itchef/cookbooks/cpe_pathsd/resources/cpe_pathsd_darwin.rb
+++ b/itchef/cookbooks/cpe_pathsd/resources/cpe_pathsd_darwin.rb
@@ -33,13 +33,4 @@ action :manage do
     group 'wheel'
     mode 0644
   end
-
-  # No one should have the ability to update /etc/paths except via API.
-  cookbook_file '/etc/paths' do
-    source 'paths'
-    owner 'root'
-    group 'wheel'
-    mode 0644
-    action :create
-  end
 end


### PR DESCRIPTION
`/etc/paths` should be managed outside of this API (imo).

This API is arbitrarily managing the system `paths` file for macOS but not Linux. 

As system paths can change, it should be left up to the org to decide if they want to manage this or not, especially since it has no impact on cpe_pathsd itself.

In fact, Apple did change system paths in catalina: 
```
/usr/local/bin
/usr/bin
/bin
/usr/sbin
/sbin
/Library/Apple/usr/bin
/Library/Apple/bin
```

The alternative would be to add to the API to allow path injection into the system `paths` file (at the top).