### PR TITLE
Use single quotes for file mode 

### DIFF
--- a/chef/cookbooks/cpe_pathsd/recipes/darwin.rb
+++ b/chef/cookbooks/cpe_pathsd/recipes/darwin.rb
@@ -15,14 +15,14 @@
 directory '/etc/paths.d/' do
   owner 'root'
   group 'wheel'
-  mode 0755
+  mode '0755'
 end
 
 template '/etc/paths.d/cpe_pathsd' do
   source 'cpe_pathsd'
   owner 'root'
   group 'wheel'
-  mode 0644
+  mode '0644'
 end
 
 # No one should have the ability to update /etc/paths though an API.
@@ -30,6 +30,6 @@ cookbook_file '/etc/paths' do
   source 'paths'
   owner root_owner
   group root_group
-  mode 0644
+  mode '0644'
   action :create
 end

--- a/itchef/cookbooks/cpe_pathsd/resources/cpe_pathsd_darwin.rb
+++ b/itchef/cookbooks/cpe_pathsd/resources/cpe_pathsd_darwin.rb
@@ -24,14 +24,14 @@ action :manage do
   directory '/etc/paths.d/' do
     owner 'root'
     group 'wheel'
-    mode 0755
+    mode '0755'
   end
 
   template '/etc/paths.d/cpe_pathsd' do
     source 'cpe_pathsd'
     owner 'root'
     group 'wheel'
-    mode 0644
+    mode '0644'
   end
 
   # No one should have the ability to update /etc/paths except via API.
@@ -39,7 +39,7 @@ action :manage do
     source 'paths'
     owner 'root'
     group 'wheel'
-    mode 0644
+    mode '0644'
     action :create
   end
 end


### PR DESCRIPTION
Makes the file mode consistent between the linux and darwin resources.