### PR TITLE
Remove old dependency and add supports for debian family

### DIFF
--- a/itchef/cookbooks/cpe_hosts/metadata.rb
+++ b/itchef/cookbooks/cpe_hosts/metadata.rb
@@ -8,6 +8,7 @@ source_url 'https://github.com/facebook/IT-CPE/tree/master/itchef/'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
 version '0.2.0'
 supports 'fedora'
+supports 'ubuntu'
+supports 'debian'
 supports 'mac_os_x'
 supports 'windows'
-depends 'line'


### PR DESCRIPTION
`line` was used at the very beginning, but we moved away from it and never removed the dependency. This fixes that.

Also, this works on debian and ubuntu, so adding supports lines for those.