### PR TITLE
By default this should manage nothing

### DIFF
--- a/itchef/cookbooks/cpe_hosts/attributes/default.rb
+++ b/itchef/cookbooks/cpe_hosts/attributes/default.rb
@@ -17,16 +17,6 @@
 #
 
 default['cpe_hosts'] = {
-  'extra_entries' => {
-    '::1' => [
-      'localhost',
-    ],
-    '127.0.0.1' => [
-      'localhost',
-    ],
-    '255.255.255.255' => [
-      'broadcasthost',
-    ],
-  },
+  'extra_entries' => {},
   'manage_by_line' => true,
 }


### PR DESCRIPTION
Since the default mode is managing hosts per line, we shouldn't manage things that already exist in a default hosts file.