### PR TITLE
Add guards to macOS-specific cookbooks

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -87,7 +87,7 @@ FileName:
 PerceivedComplexity:
   Enabled: false
 
-Lint/UnneededCopDisableDirective:
+Lint/RedundantCopDisableDirective:
   Enabled: false
 
 # Seems buggy - https://github.com/bbatsov/rubocop/issues/2690
@@ -117,7 +117,7 @@ Style/ConditionalAssignment:
 #
 # Modified rules
 #
-Metrics/LineLength:
+Layout/LineLength:
   Max: 80
 
 Layout/DotPosition:
@@ -138,7 +138,7 @@ Style/TrailingCommaInHashLiteral:
 Style/TrailingCommaInArguments:
   EnforcedStyleForMultiline: comma
 
-Layout/IndentFirstArrayElement:
+Layout/FirstArrayElementIndentation:
   EnforcedStyle: consistent
 
 Style/SignalException:

--- a/chef/cookbooks/cpe_autopkg/metadata.rb
+++ b/chef/cookbooks/cpe_autopkg/metadata.rb
@@ -9,4 +9,5 @@ version '0.1.0'
 
 # depends 'cpe_remote'
 depends 'cpe_profiles'
+depends 'cpe_utils'
 depends 'mac_os_x'

--- a/chef/cookbooks/cpe_autopkg/recipes/default.rb
+++ b/chef/cookbooks/cpe_autopkg/recipes/default.rb
@@ -29,5 +29,7 @@
 #   receipt 'com.github.autopkg.autopkg'
 # end
 
+return unless node.macos?
+
 cpe_autopkg_setup 'Set up AutoPkg'
 cpe_autopkg_update 'Add/Update AutoPkg repos'

--- a/chef/cookbooks/cpe_bluetooth/metadata.rb
+++ b/chef/cookbooks/cpe_bluetooth/metadata.rb
@@ -10,3 +10,4 @@ version '0.1.0'
 supports 'mac_os_x'
 
 depends 'cpe_profiles'
+depends 'cpe_utils'

--- a/chef/cookbooks/cpe_bluetooth/recipes/default.rb
+++ b/chef/cookbooks/cpe_bluetooth/recipes/default.rb
@@ -12,4 +12,6 @@
 # of patent rights can be found in the PATENTS file in the same directory.
 #
 
+return unless node.macos?
+
 cpe_bluetooth 'Configure Bluetooth Profile'

--- a/chef/cookbooks/cpe_desktop/metadata.rb
+++ b/chef/cookbooks/cpe_desktop/metadata.rb
@@ -10,3 +10,4 @@ version '0.1.0'
 supports 'mac_os_x'
 
 depends 'cpe_profiles'
+depends 'cpe_utils'

--- a/chef/cookbooks/cpe_desktop/recipes/default.rb
+++ b/chef/cookbooks/cpe_desktop/recipes/default.rb
@@ -12,4 +12,6 @@
 # of patent rights can be found in the PATENTS file in the same directory.
 #
 
+return unless node.macos?
+
 cpe_desktop 'Apply Preference Desktop Wallpaper'

--- a/chef/cookbooks/cpe_macos_server/recipes/default.rb
+++ b/chef/cookbooks/cpe_macos_server/recipes/default.rb
@@ -11,6 +11,8 @@
 # of patent rights can be found in the PATENTS file in the same directory.
 #
 
+return unless node.macos?
+
 # You must install Server.app first
 unless File.exist?('/Applications/Server.app')
   Chef::Log.info("#{cookbook_name}: Server.app is not installed.")

--- a/chef/cookbooks/cpe_nightly_reboot/metadata.rb
+++ b/chef/cookbooks/cpe_nightly_reboot/metadata.rb
@@ -10,3 +10,4 @@ version '0.1.0'
 supports 'mac_os_x'
 
 depends 'cpe_launchd'
+depends 'cpe_utils'

--- a/chef/cookbooks/cpe_nightly_reboot/recipes/default.rb
+++ b/chef/cookbooks/cpe_nightly_reboot/recipes/default.rb
@@ -10,4 +10,6 @@
 # of patent rights can be found in the PATENTS file in the same directory.
 #
 
+return unless node.macos?
+
 cpe_nightly_reboot 'Create nightly reboot'

--- a/chef/cookbooks/cpe_powermanagement/metadata.rb
+++ b/chef/cookbooks/cpe_powermanagement/metadata.rb
@@ -9,5 +9,5 @@ long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
 version '0.1.0'
 supports 'mac_os_x'
 
-depends 'cpe_utils'
 depends 'cpe_profiles'
+depends 'cpe_utils'

--- a/chef/cookbooks/cpe_powermanagement/recipes/default.rb
+++ b/chef/cookbooks/cpe_powermanagement/recipes/default.rb
@@ -12,4 +12,6 @@
 # of patent rights can be found in the PATENTS file in the same directory.
 #
 
+return unless node.macos?
+
 cpe_powermanagement 'Configure Power Management Profile'

--- a/chef/cookbooks/cpe_preferencepanes/metadata.rb
+++ b/chef/cookbooks/cpe_preferencepanes/metadata.rb
@@ -10,3 +10,4 @@ version '0.1.0'
 supports 'mac_os_x'
 
 depends 'cpe_profiles'
+depends 'cpe_utils'

--- a/chef/cookbooks/cpe_preferencepanes/recipes/default.rb
+++ b/chef/cookbooks/cpe_preferencepanes/recipes/default.rb
@@ -12,4 +12,6 @@
 # of patent rights can be found in the PATENTS file in the same directory.
 #
 
+return unless node.macos?
+
 cpe_preferencepanes 'Configure PreferencePanes Profile'

--- a/chef/cookbooks/cpe_screensaver/recipes/default.rb
+++ b/chef/cookbooks/cpe_screensaver/recipes/default.rb
@@ -13,4 +13,5 @@
 #
 
 return unless node.macos?
+
 cpe_screensaver 'Configure Screen Saver Profile'

--- a/chef/cookbooks/cpe_spotlight/recipes/default.rb
+++ b/chef/cookbooks/cpe_spotlight/recipes/default.rb
@@ -11,7 +11,8 @@
 # of patent rights can be found in the PATENTS file in the same directory.
 #
 
-return unless node.macosx?
+return unless node.macos?
+
 # Abort if Spotlight indexing is disabled
 spotlight_data =
   Mixlib::ShellOut.new('/usr/bin/mdutil -s /').run_command.stdout

--- a/chef/cookbooks/osx_server/metadata.rb
+++ b/chef/cookbooks/osx_server/metadata.rb
@@ -7,4 +7,5 @@ description 'Configures OS X Server.app'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
 version '0.1.0'
 
+depends 'cpe_utils'
 depends 'mac_os_x'

--- a/chef/cookbooks/osx_server/recipes/default.rb
+++ b/chef/cookbooks/osx_server/recipes/default.rb
@@ -12,7 +12,7 @@
 # of patent rights can be found in the PATENTS file in the same directory.
 #
 
-return unless node.macosx?
+return unless node.macos?
 
 # Configure service directories, account
 include_recipe 'osx_server::setup'


### PR DESCRIPTION
This PR, if merged, will add the `return unless node.macos?` guard to cookbooks which are only targeting macOS. This change seems to be in lockstep with other cookbooks in the repository which already have this written into them (i.e. `cpe_munki`, `cpe_deprecation_notifier`, `cpe_nomad`, et al).

Another small change I've made is to flip over 2x instances of `node.macosx?` to `node.macos?`. I know it is a super insignificant modification, but I believe it makes locating all instances of macOS guards easier if they're consistent. I considered removing the definition of `macosx?` from `cpe_utils/libraries/node_functions.rb`, but felt this change could have too many downstream ramifications and, therefore, wasn't worth it the risk.