### PR TITLE
Rm `node.installed?('Google Chrome')` guard in `cpe_chrome`

### DIFF
--- a/chef/cookbooks/cpe_chrome/resources/cpe_chrome_win.rb
+++ b/chef/cookbooks/cpe_chrome/resources/cpe_chrome_win.rb
@@ -21,7 +21,7 @@ action :config do
   chrome_installed = ::File.file?(
     "#{ENV['ProgramFiles(x86)']}\\Google\\Chrome\\Application\\chrome.exe",
   )
-  return unless node.installed?('Google Chrome') || chrome_installed
+  return unless chrome_installed
   return unless node['cpe_chrome']['profile'].values.any?
 
   reg_settings = []


### PR DESCRIPTION
The `node.installed?` guard called in `cpe_chrome_win` resource but that is a macOS-only function. In turn, `installed?` then calls upon `app_paths_deprecated` which is also a macOS-only function.

Because of this, Chef client logs are unavoidably getting hit with 2x warnings. Assuming the other guard (`chrome_installed`) is working just fine to evaluate Chrome's existence on a Windows endpoint because the `installed?` guard surely isn't.