### PR TITLE
Flip Chrome existence-check logic

### DIFF
--- a/itchef/cookbooks/cpe_chrome/resources/cpe_chrome_win.rb
+++ b/itchef/cookbooks/cpe_chrome/resources/cpe_chrome_win.rb
@@ -26,7 +26,7 @@ action :config do
   chrome_installed = ::File.file?(
     "#{ENV['ProgramFiles(x86)']}\\Google\\Chrome\\Application\\chrome.exe",
   )
-  return unless node.installed?('Google Chrome') || chrome_installed
+  return unless chrome_installed || node.installed?('Google Chrome')
   return unless node['cpe_chrome']['profile'].values.any?
 
   # ExtensionSettings has a "dictionary" format and each key must be stored


### PR DESCRIPTION
Allows for error-less way of non-osquery-leveraging Windows endpoints of evaluating Chrome's existence without cluttering logs with warnings.