### PR TITLE
Re-sync with internal repository

### DIFF
--- a/itchef/cookbooks/cpe_munki/README.md
+++ b/itchef/cookbooks/cpe_munki/README.md
@@ -1,0 +1,228 @@
+cpe_munki Cookbook
+==================
+cpe_munki can install and configure Munki, remediate broken installs, and manage
+local-only manifests.
+
+Requirements
+------------
+* macOS
+
+Attributes
+----------
+* node['cpe_munki']['auto_remediate']
+* node['cpe_munki']['configure']
+* node['cpe_munki']['install']
+* node['cpe_munki']['skip_enforcing_launchds']
+* node['cpe_munki']['local']['managed_installs']
+* node['cpe_munki']['local']['managed_uninstalls']
+* node['cpe_munki']['local']['optional_installs']
+* node['cpe_munki']['munki_version_to_install']
+* node['cpe_munki']['preferences']
+
+Usage
+-----
+This cookbook handles the various aspects of a Munki install. To use this
+cookbook, set the attributes according to what you want to do and the cookbook
+will handle the rest.
+
+Examples:
+
+### Install Munki and do nothing else
+
+```
+    node.default['cpe_munki']['install']  = true
+```
+
+### Install and configure Munki
+
+```
+node.default['cpe_munki']['install'] = true
+node.default['cpe_munki']['configure'] = true
+node.default['cpe_munki']['preferences']['SoftwareRepoURL'] =
+  'https://munki.MYCOMPANY.com/repo'
+node.default['cpe_munki']['preferences']['InstallAppleSoftwareUpdates'] = true
+```
+
+### Only configure Munki
+
+```
+node.default['cpe_munki']['configure'] = true
+node.default['cpe_munki']['preferences']['SoftwareRepoURL'] = https://munki.MYCOMPANY.com/repo'
+node.default['cpe_munki']['preferences']['InstallAppleSoftwareUpdates'] = true
+node.default['cpe_munki']['preferences']['AppleSoftwareUpdatesOnly'] = true
+```
+
+Advanced Example:
+
+Note: You must have a Munki server setup and all packages you add to this
+attribute must be available in the node's catalogs
+
+#### Add `managed_installs` using a local manifest
+
+```ruby
+managed_installs = [
+  'Firefox',
+  'Chrome'
+]
+managed_installs.each do |item|
+  node.default['cpe_munki']['local']['managed_installs'] << item
+end
+```
+
+#### Add `optional_installs` using a local manifest
+
+```ruby
+optional_installs = [
+  'Dropbox'
+]
+optional_installs.each do |item|
+  node.default['cpe_munki']['local']['optional_installs'] << item
+end
+```
+
+### Installing Munki
+The 'cpe_munki_install' resource will install Munki. You must set the `install`
+attribute to be `true` in order to install the Munki packages:
+
+  node.default['cpe_munki']['install'] = true
+
+By default, Munki releases from Github come as a single distribution package,
+which contain the separate subpackages inside. You can separate out the component
+packages with `pkgutil`:
+
+```
+/usr/sbin/pkgutil --expand munkitools-3.0.3.3333.pkg munkitools3
+```
+
+Munki will determine what packages to install by looping through all the keys in
+ `node['cpe_munki']['munki_version_to_install']`.
+Each key should correspond to a hash that contains the version of the package,
+and its SHA256 checksum. To configure a client to install Munki 3 in its entirety:
+
+```ruby
+    {
+      'launchd' => {
+        'version' => '3.0.3265',
+        'checksum' =>
+        'b3871f6bb3522ce5e46520bcab06aed2644bf11265653f6114a0e34911f17914',
+      },
+      'admin' => {
+        'version' => '3.2.0.3476',
+        'checksum' =>
+          '863614a59ba8ee4cb5730ff708fbdcb9fa4c248b456802fce28303ad9e312c17',
+      },
+      'app' => {
+        'version' => '4.7.3445',
+        'checksum' =>
+          '50e946983a48a33a62c4e6115875500af1d2a46254415946f90bcc121c577816',
+      },
+      'app_usage' => {
+        'version' => '3.2.0.3476',
+        'checksum' =>
+          '62c9e2238bde906c968203e09088d4dcb4bb0e82d9c9d7683b3f8024263e79ef',
+      },
+      'core' => {
+        'version' => '3.2.0.3476',
+        'checksum' =>
+          '5319e29efb89f6c5b97c6976772da564f9c4781b802c582a895feb32678c83a8',
+      },
+    }.each do |k, v|
+      node.default['cpe_munki']['munki_version_to_install'][k] = v
+    end
+```
+
+The `install` resource will loop through all the package names and use `cpe_remote`
+to download the package from `node['cpe_remote']['base_url']`, verify the checksum
+of the downloaded file matches, and then install it. You can override the URL on
+a per-package basis if you so wish:
+
+```ruby
+node.default['cpe_munki']['munki_version_to_install']['admin'] = {
+  'version' => '3.0.0.3333',
+  'url' => 'foo.com/path/to/munkitools_admin.pkg'
+  'checksum' => '42fb19dbaa1d24691a596a3d60e900f57d2b9d6e1a8018972fe4c52c2f988682',
+}
+```
+
+### Selectively enforcing Munki LaunchDaemons
+
+By default, all Munki launch daemons and launch agents are loaded and enforced
+every Chef run. If you want to stop enforcing any specific launch daemons/agents,
+you can add the name after the prefix to the
+`node['cpe_munki']['skip_enforcing_launchds']` array.
+
+Since all Munki launch daemons/agents share the same prefix of "com.googlecode.munki",
+you only need to add the last portion to this list. For example, you could use
+this to prevent Chef from enforcing that the logout helper launch daemon is loaded:
+
+```
+node.default['cpe_munki']['skip_enforcing_launchds'] += ['logouthelper']
+```
+
+### Munki Configuration
+The 'cpe_munki_config' resource will install a profile that configures Munki settings.
+You must set `node['cpe_munki']['config']` to be `true` for this to run.
+
+By leveraging `cpe_profiles`, we can craft a profile that has the base settings
+we want to apply. The default settings are stored in `node['cpe_munki']['preferences']`.
+Those values can be overridden in any recipe to be applied as you want:
+
+```ruby
+# Munki attribute overrides
+{
+  'DaysBetweenNotifications' => 90,
+  'InstallAppleSoftwareUpdates' => true,
+  'SoftwareRepoURL' => "https://#{server}/repo"
+}.each do |k, v|
+  node.default['cpe_munki']['preferences'][k] = v
+end
+```
+
+### Local Manifests
+The 'cpe_munki_local' resource will implement a local-only manifest.
+
+Local Munki is where items from the `node['cpe_munki']['local']['managed_installs']`
+and `node['cpe_munki']['local']['managed_uninstalls']` node attributes are added
+to a local manifest in the respective `managed_installs` and `managed_uninstalls`
+keys.  This allows any individual (or group, or node, etc.) to specify an existing
+optional install as either an install or uninstall.  Adding an item to either of
+these two attributes will combine with the existing client manifest.
+
+If an item is removed from `managed_installs` or `managed_uninstalls` in this
+manner, Munki will no longer forcefully manage its installation or removal.
+If an item is added to `managed_uninstalls`, it is also removed from the
+'managed_installs' array of the SelfServeManifest if the item exists there.
+
+The default list of items to be installed on clients is in
+`cpe_munki::managed_installs`. Anyone can override this value to add or remove
+things that they want (or don't want).
+
+```ruby
+# How to install one App:
+node.default['cpe_munki']['local']['managed_installs'] << 'Firefox'
+```
+
+```ruby
+# How to install a list of Apps:
+    [
+      'Firefox',
+      'GoogleChrome',
+      'Atom',
+      'Dropbox',
+    ].each do |item|
+      node.default['cpe_munki']['local']['managed_installs'] << item
+    end
+```
+
+### Auto Remediation
+This cookbook can also attempt to remediate broken Munki installs.
+
+Set `node['cpe_munki']['auto_remediate']` to the amount of days Chef should
+allow Munki to not run before reinstalling all packages. Chef will read the
+/Library/Preferences/ManagedInstalls preferences domain to parse the
+`LastCheckDate` key. If that key is older than the number of days specified, all
+package receipts are forgotten and Chef will reinstall the Munki packages.
+
+```
+node.default['cpe_munki']['auto_remediate'] = 30
+```

--- a/itchef/cookbooks/cpe_munki/attributes/default.rb
+++ b/itchef/cookbooks/cpe_munki/attributes/default.rb
@@ -1,0 +1,76 @@
+#
+# Cookbook Name:: cpe_munki
+# Attributes:: default
+#
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+default['cpe_munki'] = {
+  'install' => false,
+  'configure' => false,
+  'auto_remediate' => nil,
+  'skip_enforcing_launchds' => [],
+  'munki_version_to_install' => {},
+  'local' => {
+    'managed_installs' => [],
+    'managed_uninstalls' => [],
+    'optional_installs' => [],
+  },
+  'preferences' => {
+    'AppleSoftwareUpdatesOnly' => nil,
+    'DaysBetweenNotifications' => nil,
+    'FollowHTTPRedirects' => nil,
+    'InstallAppleSoftwareUpdates' => nil,
+    'LogFile' => nil,
+    'LoggingLevel' => nil,
+    'LogToSyslog' => nil,
+    'PerformAuthRestarts' => nil,
+    'RecoveryKeyFile' => nil,
+    'SoftwareRepoURL' => nil,
+    'SuppressAutoInstall' => nil,
+    'SuppressStopButtonOnInstall' => nil,
+    'SuppressUserNotification' => nil,
+    'UnattendedAppleUpdates' => nil,
+    'UseClientCertificate' => nil,
+    'UseNotificationCenterDays' => nil,
+  },
+}
+
+# # Example of what to set in your company_init.rb
+# node.default['cpe_munki']['munki_version_to_install']['admin'] = {
+#   'version' => '3.0.0.3333',
+#   'checksum' =>
+#     '42fb19dbaa1d24691a596a3d60e900f57d2b9d6e1a8018972fe4c52c2f988682',
+# }
+# node.default['cpe_munki']['munki_version_to_install']['app'] = {
+#   'version' => '4.6.3330',
+#   'checksum' =>
+#   'f1354f99bececdabc0549531e50e1362a332a8e4802a07066e6bc0e74b72258d',
+# }
+# node.default['cpe_munki']['munki_version_to_install']['app_usage'] = {
+#   'version' => '3.0.0.3333',
+#   'checksum' =>
+#   'bc3299823d024982122de3d98905d28d6bf36585b060f7a0526a591c45815ad4',
+# }
+# node.default['cpe_munki']['munki_version_to_install']['core'] = {
+#   'version' => '3.0.0.3333',
+#   'checksum' =>
+#   'd82dd386d7aebe459314b7d62da993732e2b1e08813f305fab08ece10e2e330d',
+# }
+# node.default['cpe_munki']['munki_version_to_install']['launchd'] = {
+#   'version' => '3.0.3265',
+#   'checksum' =>
+#   'b3871f6bb3522ce5e46520bcab06aed2644bf11265653f6114a0e34911f17914',
+# }

--- a/itchef/cookbooks/cpe_munki/metadata.rb
+++ b/itchef/cookbooks/cpe_munki/metadata.rb
@@ -1,0 +1,13 @@
+# Copyright (c) Facebook, Inc. and its affiliates.
+
+name 'cpe_munki'
+maintainer 'Facebook'
+maintainer_email 'noreply@facebook.com'
+license 'Apache-2.0'
+description 'Installs/Configures Munki'
+long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
+version '0.3.0'
+
+depends 'cpe_remote'
+depends 'cpe_helpers'
+depends 'cpe_profiles'

--- a/itchef/cookbooks/cpe_munki/recipes/default.rb
+++ b/itchef/cookbooks/cpe_munki/recipes/default.rb
@@ -1,0 +1,24 @@
+#
+# Cookbook Name:: cpe_munki
+# Recipe:: default
+#
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+return unless node.macos?
+
+cpe_munki_install 'Install Munki'
+cpe_munki_local 'Manage Local Munki Manifest'
+cpe_munki_config 'Manage Munki Settings'

--- a/itchef/cookbooks/cpe_munki/resources/cpe_munki_config.rb
+++ b/itchef/cookbooks/cpe_munki/resources/cpe_munki_config.rb
@@ -1,0 +1,57 @@
+#
+# Cookbook Name:: cpe_munki
+# Resource:: cpe_munki_config
+#
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+resource_name :cpe_munki_config
+default_action :config
+
+action :config do
+  return unless node['cpe_munki']['configure']
+
+  munki_prefs = node['cpe_munki']['preferences'].reject { |_k, v| v.nil? }
+  if munki_prefs.empty?
+    Chef::Log.info("#{cookbook_name}: No prefs found.")
+    return
+  end
+
+  prefix = node['cpe_profiles']['prefix']
+  organization = node['organization'] ? node['organization'] : 'Facebook'
+
+  munki_profile = {
+    'PayloadIdentifier' => "#{prefix}.munki",
+    'PayloadRemovalDisallowed' => true,
+    'PayloadScope' => 'System',
+    'PayloadType' => 'Configuration',
+    'PayloadUUID' => 'a3f3dc40-1fde-0131-31d5-000c2944c108',
+    'PayloadOrganization' => organization,
+    'PayloadVersion' => 1,
+    'PayloadDisplayName' => 'Munki',
+    'PayloadContent' => [{
+      'PayloadType' => 'ManagedInstalls',
+      'PayloadVersion' => 1,
+      'PayloadIdentifier' => "#{prefix}.munki",
+      'PayloadUUID' => '7059fe60-222f-0131-31db-000c2944c108',
+      'PayloadEnabled' => true,
+      'PayloadDisplayName' => 'Munki',
+    }],
+  }
+  munki_prefs.each do |k, v|
+    munki_profile['PayloadContent'][0][k] = v
+  end
+  node.default['cpe_profiles']["#{prefix}.munki"] = munki_profile
+end

--- a/itchef/cookbooks/cpe_munki/resources/cpe_munki_install.rb
+++ b/itchef/cookbooks/cpe_munki/resources/cpe_munki_install.rb
@@ -1,0 +1,123 @@
+#
+# Cookbook Name:: cpe_munki
+# Resource:: cpe_munki_install
+#
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+resource_name :cpe_munki_install
+default_action :install
+
+action_class do
+  def managed_installs
+    '/Library/Preferences/ManagedInstalls'
+  end
+
+  def read_munki_lastcheckdate
+    begin
+      defaults_cmd = shell_out(
+        "/usr/bin/defaults read #{managed_installs} LastCheckDate",
+      ).stdout
+      last_check_date = Date.parse(defaults_cmd)
+    rescue ArgumentError
+      log("Unable to parse LastCheckDate: #{defaults_cmd}")
+      last_check_date = Date.today
+    end
+    last_check_date
+  end
+
+  def write_munki_lastcheckdate(time)
+    execute "defaults write #{managed_installs} LastCheckDate '#{time}'"
+  end
+
+  def remediate?
+    return unless node['cpe_munki']['auto_remediate']
+    # There is a chance that this is prior to the first run,
+    # file might not be present.
+    return unless ::File.exist?("#{managed_installs}.plist")
+    # getting value for the last munki check-in
+    last_check_date = read_munki_lastcheckdate
+    # if it's greater than the remediate_window since munki last ran.
+    today = Date.today
+    remediate_window = node['cpe_munki']['auto_remediate'].to_i
+    return unless (today - last_check_date).to_i > remediate_window
+
+    # and the pkg is installed
+    node['cpe_munki']['munki_version_to_install'].to_h.each do |pkg, _opts|
+      receipt = "com.googlecode.munki.#{pkg}"
+      next if shell_out(
+        "/usr/sbin/pkgutil --pkg-info='#{receipt}'",
+      ).error?
+      # forget the pkg
+      execute "/usr/sbin/pkgutil --forget #{receipt}"
+    end
+    write_munki_lastcheckdate(Time.now)
+  end
+end
+
+action :install do
+  return unless node['cpe_munki']['install']
+  m = 'com.googlecode.munki'
+  remediate?
+  node['cpe_munki']['munki_version_to_install'].to_h.each do |pkg, opts|
+    package_version = opts['version']
+    package_name = "munkitools_#{pkg}-#{package_version}"
+    cpe_remote_pkg "munkitools_#{pkg}" do # ~FC037
+      app 'munkitools'
+      pkg_name package_name
+      pkg_url opts['url'] if opts['url']
+      checksum opts['checksum']
+      receipt "com.googlecode.munki.#{pkg}"
+      version package_version
+      if pkg.include?('launchd')
+        notifies :restart, "launchd[#{m}.logouthelper]"
+        notifies :restart, "launchd[#{m}.managedsoftwareupdate-check]"
+        notifies :restart, "launchd[#{m}.managedsoftwareupdate-manualcheck]"
+        notifies :restart, "launchd[#{m}.authrestartd]"
+        notifies :restart, "launchd[#{m}.managedsoftwareupdate-install]"
+        notifies :restart, "launchd[#{m}.app_usage_monitor]"
+        notifies :restart, "launchd[#{m}.munki-notifier]"
+        notifies :restart, "launchd[#{m}.ManagedSoftwareCenter]"
+      end
+    end
+  end
+
+  [
+    'logouthelper',
+    'managedsoftwareupdate-check',
+    'managedsoftwareupdate-manualcheck',
+    'authrestartd',
+    'managedsoftwareupdate-install',
+    'app_usage_monitor',
+  ].each do |d|
+    launchd "#{m}.#{d}" do
+      not_if { node['cpe_munki']['skip_enforcing_launchds'].include?(d) }
+      only_if { ::File.exist?("/Library/LaunchDaemons/#{m}.#{d}.plist") }
+      action :enable
+    end
+  end
+
+  [
+    'munki-notifier',
+    'ManagedSoftwareCenter',
+  ].each do |a|
+    launchd "#{m}.#{a}" do
+      not_if { node['cpe_munki']['skip_enforcing_launchds'].include?(a) }
+      only_if { ::File.exist?("/Library/LaunchAgents/#{m}.#{a}.plist") }
+      type 'agent'
+      action :enable
+    end
+  end
+end

--- a/itchef/cookbooks/cpe_munki/resources/cpe_munki_local.rb
+++ b/itchef/cookbooks/cpe_munki/resources/cpe_munki_local.rb
@@ -1,0 +1,148 @@
+#
+# Cookbook Name:: cpe_munki
+# Resource:: cpe_munki_local
+#
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+require 'plist'
+require 'json'
+
+resource_name :cpe_munki_local
+default_action :run
+
+action :run do
+  locals_exist = node['cpe_munki']['local']['managed_installs'].any? ||
+                node['cpe_munki']['local']['managed_uninstalls'].any?
+
+  return unless locals_exist
+  return unless ::File.exist?('/usr/local/munki/managedsoftwareupdate')
+
+  # If local only manifest preference is not set,
+  # set it to the default 'extra_packages'
+  unless node['cpe_munki']['preferences'].key?('LocalOnlyManifest')
+    node.default['cpe_munki']['preferences']['LocalOnlyManifest'] =
+      'extra_packages'
+  end
+
+  @catalog_items = parse_items_in_catalogs
+
+  local_manifest = node['cpe_munki']['preferences']['LocalOnlyManifest']
+  file "/Library/Managed Installs/manifests/#{local_manifest}" do # ~FC005
+    owner 'root'
+    group 'wheel'
+    mode '644'
+    content gen_plist
+  end
+
+  file '/Library/Managed Installs/manifests/SelfServeManifest' do
+    not_if { node['cpe_munki']['local']['managed_uninstalls'].empty? }
+    only_if do
+      ::File.exist?('/Library/Managed Installs/manifests/SelfServeManifest')
+    end
+    owner 'root'
+    group 'wheel'
+    mode '644'
+    content gen_selfservice_plist
+  end
+
+  # This file is for context for users to know whats avalible for their machine
+  pretty_json = JSON.pretty_generate(@catalog_items)
+  file '/Library/Managed Installs/munki_catalog_items.json' do
+    owner 'root'
+    group 'wheel'
+    mode '644'
+    content pretty_json.to_s
+  end
+end
+
+def validate_install_array(install_array)
+  catalog_items = parse_items_in_catalogs
+  return install_array if catalog_items.empty?
+  ret = []
+  install_array.uniq.each do |item|
+    item_no_ver = item.split('-')[0] # strip version component of item
+    if catalog_items.include?(item_no_ver)
+      ret << item
+    else
+      ::Chef::Log.warn(
+        "#{cookbook_name}: item not found in catalogs: #{item}",
+      )
+    end
+  end
+  ret.uniq.sort
+end
+
+def gen_plist
+  installs = validate_install_array(
+    node['cpe_munki']['local']['managed_installs'],
+  )
+  uninstalls = validate_install_array(
+    node['cpe_munki']['local']['managed_uninstalls'],
+  )
+  optionals = validate_install_array(
+    node['cpe_munki']['local']['optional_installs'],
+  )
+  plist_hash = {
+    'managed_installs' => installs,
+    'managed_uninstalls' => uninstalls,
+    'optional_installs' => optionals,
+  }
+  ::Chef::Log.info("#{cookbook_name}: Managed installs: #{installs}")
+  unless optionals.empty?
+    ::Chef::Log.info("#{cookbook_name}: Optional installs: #{optionals}")
+  end
+  Plist::Emit.dump(plist_hash) unless plist_hash.nil?
+end
+
+def gen_selfservice_plist
+  self_serve_file = '/Library/Managed Installs/manifests/SelfServeManifest'
+  return nil unless ::File.exist?(self_serve_file)
+  ss_manifest = read_plist(self_serve_file)
+  uninstalls = validate_install_array(
+    node['cpe_munki']['local']['managed_uninstalls'],
+  )
+  # remove uninstalls from ss_manifest array
+  ss_manifest['managed_installs'] =
+    ss_manifest['managed_installs'] - uninstalls
+
+  ::Chef::Log.info(
+    "#{cookbook_name}: Cleanup Self Service: #{uninstalls}",
+  )
+  Plist::Emit.dump(ss_manifest)
+end
+
+def read_plist(xml_file)
+  Plist.parse_xml(xml_file)
+end
+
+def parse_items_in_catalogs
+  catalogs = []
+  catlogs_dir = '/Library/Managed Installs/catalogs/'
+  Dir.foreach(catlogs_dir) do |catalog|
+    next if ['.', '..'].include?(catalog)
+    begin
+      p = read_plist(catlogs_dir + catalog)
+      p.each do |d|
+        catalogs << d['name']
+      end
+    rescue StandardError
+      next
+    end
+  end
+  catalogs.uniq
+rescue StandardError
+  []
+end


### PR DESCRIPTION
The internal and external repositories are out of sync. This attempts to brings them back in sync by patching the GitHub repository. Please carefully review this patch. You must disable ShipIt for your project in order to merge this pull request. DO NOT IMPORT this pull request. Instead, merge it directly on GitHub using the MERGE BUTTON. Re-enable ShipIt after merging.