### PR TITLE
Add Chrome Extension management support and fix idempotency on windows

### DIFF
--- a/itchef/cookbooks/cpe_chrome/attributes/default.rb
+++ b/itchef/cookbooks/cpe_chrome/attributes/default.rb
@@ -22,6 +22,19 @@ default['cpe_chrome'] = {
   'validate_installed' => false,
   'install_package' => false,
   'manage_repo' => false,
+  'extension_profile' => {
+    # '1234567890qwertyuiop' => {
+    #   'display_name' => 'Example Extension',
+    #   'payload_uuid' => '9D359A7A-EF21-4D02-8186-001974CEB796',
+    #   'profile_uuid' => 'EAA802D2-D139-474A-87CE-1DEEDCCECBAE',
+    #   'profile' => {
+    #     'KeyName' => {
+    #       'windows_value_type' => :string,
+    #       'value' => 'some_string',
+    #     },
+    #   },
+    # },
+  },
   'profile' => {
     'AutoplayWhitelist' => [],
     'ExtensionInstallForcelist' => [],

--- a/itchef/cookbooks/cpe_chrome/libraries/chrome_windows.rb
+++ b/itchef/cookbooks/cpe_chrome/libraries/chrome_windows.rb
@@ -33,6 +33,10 @@ module CPE
         'HKLM\\Software\\Policies\\Google\\Chrome'.freeze
       end
 
+      def self.chrome_reg_3rd_party_ext_root
+        'HKLM\\Software\\Policies\\Google\\Chrome\\3rdparty\\extensions'.freeze
+      end
+
       # These are keys that will take some of the more complex data types used
       # in the Windows registry. Values are grabbed from:
       # https://dl.google.com/dl/edgedl/chrome/policy/policy_templates.zip


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
This PR gives you the ability to manage chrome extension settings directly, following the guide from: https://www.chromium.org/administrators/configuring-policy-for-extensions

We have been using this for a few months to manage a 3rd party extension, but because of earlier forks to cpe_chrome (and us not using cpe_helpers) it has been a bit to untangle everything.

**Which issue(s) this PR fixes**:
This also fixes some idempotency issues I discovered while testing this diff around `nil` values and `empty` hashes on windows.

If you do not manage these values, `_use_new_windows_provider` will consistently delete the keys, then create new empty/nil keys over and over. The values most impacted seem to be the ones put into the defaults `attributes.rb` file.

**Special notes for your reviewer**:
Please note that I cannot follow the new windows provider logic for extensions as only the admin may know what keys to set and what value types these are (think internal extensions). We will **never** have an attribute map.

I prefer this method as while there is an additional step on the admin, it means that any arbitrary key can be managed without the need for `cpe_chrome` to be updated.

**Does this PR introduce a user-facing change?**:
NONE

**Additional documentation e.g., Design Proposals, usage docs, etc.**:
In my humble opinion, I think moving Windows to a method like this in general might be a better approach than the utter insanity that is windows registry munging. This also more closely matches how macOS and Linux management are handled.