### PR TITLE
Replace #Hash.reject with #Hash.compact

### DIFF
--- a/itchef/cookbooks/cpe_adobe_flash/resources/configure_adobe_flash_darwin.rb
+++ b/itchef/cookbooks/cpe_adobe_flash/resources/configure_adobe_flash_darwin.rb
@@ -27,7 +27,7 @@ action_class do
   def configure
     return unless node['cpe_adobe_flash']['configure']
 
-    configs = node['cpe_adobe_flash']['configs'].reject { |_k, v| v.nil? }
+    configs = node['cpe_adobe_flash']['configs'].compact
     # Until adobe removes this problematic naming convention,
     # we still have to use it.
     {

--- a/itchef/cookbooks/cpe_adobe_flash/resources/configure_adobe_flash_windows.rb
+++ b/itchef/cookbooks/cpe_adobe_flash/resources/configure_adobe_flash_windows.rb
@@ -23,7 +23,7 @@ action_class do
   def configure
     return unless node['cpe_adobe_flash']['configure']
 
-    configs = node['cpe_adobe_flash']['configs'].reject { |_k, v| v.nil? }
+    configs = node['cpe_adobe_flash']['configs'].compact
     node.default['cpe_adobe_flash']['_applied_configs'] = configs
 
     template ::File.join(config_dir, 'mms.cfg') do # ~FB031

--- a/itchef/cookbooks/cpe_bluetooth/resources/cpe_bluetooth.rb
+++ b/itchef/cookbooks/cpe_bluetooth/resources/cpe_bluetooth.rb
@@ -20,7 +20,7 @@ provides :cpe_bluetooth, :os => 'darwin'
 default_action :config
 
 action :config do
-  prefs = node['cpe_bluetooth'].reject { |_k, v| v.nil? }
+  prefs = node['cpe_bluetooth'].compact
   if prefs.empty?
     Chef::Log.info("#{cookbook_name}: No prefs found.")
     return

--- a/itchef/cookbooks/cpe_chrome/resources/cpe_chrome_posix.rb
+++ b/itchef/cookbooks/cpe_chrome/resources/cpe_chrome_posix.rb
@@ -69,7 +69,7 @@ action_class do
       !node.installed?('com.google.Chrome')
     if node['cpe_chrome']['mp']['UseMasterPreferencesFile']
       mprefs =
-        node['cpe_chrome']['mp']['FileContents'].reject { |_k, v| v.nil? }
+        node['cpe_chrome']['mp']['FileContents'].compact
     else
       mprefs = {}
     end

--- a/itchef/cookbooks/cpe_munki/resources/cpe_munki_config.rb
+++ b/itchef/cookbooks/cpe_munki/resources/cpe_munki_config.rb
@@ -22,7 +22,7 @@ default_action :config
 action :config do
   return unless node['cpe_munki']['configure']
 
-  munki_prefs = node['cpe_munki']['preferences'].reject { |_k, v| v.nil? }
+  munki_prefs = node['cpe_munki']['preferences'].compact
   if munki_prefs.empty?
     Chef::Log.info("#{cookbook_name}: No prefs found.")
     return

--- a/itchef/cookbooks/cpe_munki/resources/cpe_munki_defaults_config.rb
+++ b/itchef/cookbooks/cpe_munki/resources/cpe_munki_defaults_config.rb
@@ -22,7 +22,7 @@ action :config do
   return unless node['cpe_munki']['configure']
 
   munki_prefs = node['cpe_munki'][
-    'defaults_preferences'].reject { |_k, v| v.nil? }
+    'defaults_preferences'].compact
 
   if munki_prefs.empty?
     Chef::Log.info("#{cookbook_name}: No defaults prefs found.")

--- a/itchef/cookbooks/cpe_nomad/resources/darwin.rb
+++ b/itchef/cookbooks/cpe_nomad/resources/darwin.rb
@@ -74,11 +74,11 @@ action_class do
 
   def configure_profile
     nomad_prefs =
-      node['cpe_nomad']['prefs'].reject { |_k, v| v.nil? }
+      node['cpe_nomad']['prefs'].compact
     login_prefs =
-      node['cpe_nomad']['login']['prefs'].reject { |_k, v| v.nil? }
+      node['cpe_nomad']['login']['prefs'].compact
     actions_prefs =
-      node['cpe_nomad']['actions']['prefs'].reject { |_k, v| v.nil? }
+      node['cpe_nomad']['actions']['prefs'].compact
     if [
       nomad_prefs,
       login_prefs,

--- a/itchef/cookbooks/cpe_powermanagement/resources/cpe_powermanagement.rb
+++ b/itchef/cookbooks/cpe_powermanagement/resources/cpe_powermanagement.rb
@@ -21,7 +21,7 @@ provides :cpe_powermanagement, :os => 'darwin'
 default_action :config
 
 action :config do
-  pw_prefs = node['cpe_powermanagement'].reject { |_k, v| v.nil? }
+  pw_prefs = node['cpe_powermanagement'].compact
   if pw_prefs.empty?
     Chef::Log.debug("#{cookbook_name}: No prefs found.")
     return
@@ -58,9 +58,9 @@ action :config do
 
   pm_prefs = {
     'ACPower' =>
-      node['cpe_powermanagement']['ACPower'].reject { |_k, v| v.nil? },
+      node['cpe_powermanagement']['ACPower'].compact,
     'Battery' =>
-      node['cpe_powermanagement']['Battery'].reject { |_k, v| v.nil? },
+      node['cpe_powermanagement']['Battery'].compact,
   }
 
   # Apply all settings to the profile - AC and/or Battery

--- a/itchef/cookbooks/cpe_preferencepanes/resources/default.rb
+++ b/itchef/cookbooks/cpe_preferencepanes/resources/default.rb
@@ -21,7 +21,7 @@ default_action :config
 
 # rubocop:disable Metrics/BlockLength
 action :config do
-  prefs = node['cpe_preferencepanes'].reject { |_k, v| v.nil? }
+  prefs = node['cpe_preferencepanes'].compact
   return if prefs.empty?
   prefix = node['cpe_profiles']['prefix']
   organization = node['organization'] ? node['organization'] : 'Facebook'

--- a/itchef/cookbooks/cpe_profiles_local/README.md
+++ b/itchef/cookbooks/cpe_profiles_local/README.md
@@ -32,7 +32,7 @@ to `node.default['cpe_profiles_local']`
 For instance, add a hash to manage the loginwindow and use the default prefix:
 
 ```
-lw_prefs = node['cpe_loginwindow'].reject { |\_k, v| v.nil? }
+lw_prefs = node['cpe_loginwindow'].compact
 if lw_prefs.empty?
   Chef::Log.debug("#{cookbook_name}: No prefs found.")
   return
@@ -77,7 +77,7 @@ Or, if you want to customize the prefix and then add a profile, you would do:
 # Override the default prefix value of 'com.facebook.chef'
 node.default['cpe_profiles_local']['prefix'] = 'com.company.chef'
 # Use the specified prefix to name the configuration profile
-lw_prefs = node['cpe_loginwindow'].reject { |\_k, v| v.nil? }
+lw_prefs = node['cpe_loginwindow'].compact
 if lw_prefs.empty?
   Chef::Log.debug("#{cookbook_name}: No prefs found.")
   return


### PR DESCRIPTION
This PR will do one thing: Replace all instances of #Hash.reject { |_k, v | v.nil? } with #Hash.compact.

This has been shown (https://github.com/chef/chef/pull/10601) to increase speed by a reasonable amount and is a bit more simple (IMHO).

Tested this locally with Chef Solo and -- with a sample size of 4x runs -- our run_list went from an average run time of 30s (using .reject) to 24s (using .compact).