### PR TITLE
Various minor spelling corrections

### DIFF
--- a/itchef/README.md
+++ b/itchef/README.md
@@ -56,7 +56,7 @@ node.default['cpe_launchd']['doesnothing'] = {
 ```
 
 Because cpe_launchd uses the prefix set in company_init.rb, we do not need to specify a
-full reverse domain name. cpe_launchd is smart enought to build the correct reverse
+full reverse domain name. cpe_launchd is smart enough to build the correct reverse
 domain name for the LaunchDaemon.
 
 In Terminal, cd to the `itchef` directory and do a local chef run:

--- a/itchef/cookbooks/cpe_applocker/README.md
+++ b/itchef/cookbooks/cpe_applocker/README.md
@@ -53,7 +53,7 @@ The AppLocker rules are specified by a ruby Hash, which is converted to and
 from an XML blob to be shipped to AppLocker via the `Nokogiri::XML` parser.
 There are 5 total rule sets one can configured,
 [completely detailed in this MSDN article](https://docs.microsoft.com/en-us/windows/security/threat-protection/windows-defender-application-control/applocker/working-with-applocker-rules#rule-collections).
-In short, one can control the exection of the following types of applications
+In short, one can control the execution of the following types of applications
 on a windows host:
 
 * Executable Files: `.exe`, `.com`

--- a/itchef/cookbooks/cpe_applocker/libraries/applocker_helpers.rb
+++ b/itchef/cookbooks/cpe_applocker/libraries/applocker_helpers.rb
@@ -193,7 +193,7 @@ module CPE
     def gen_applocker_xml
       require 'nokogiri'
 
-      # Generical XML builder function. When enabled, this produces our
+      # Generic XML builder function. When enabled, this produces our
       # XML for enabling the Applocker service. When disabled, this produces
       # a "clean" XML policy for Applocker configuration
       builder = Nokogiri::XML::Builder.new do |xml|

--- a/itchef/cookbooks/cpe_dconf/resources/cpe_dconf.rb
+++ b/itchef/cookbooks/cpe_dconf/resources/cpe_dconf.rb
@@ -60,7 +60,7 @@ action :update do
   node['cpe_dconf']['settings'].each do |comp, settings_raw|
     # Here, each key can correspond to either a primitive (like a string), where
     # we assume lock=true, or it can be a hash, in order to disable locking.
-    # This step will process settings to determien the lock status for each key.
+    # This step will process settings to determine the lock status for each key.
     settings_processed = {}
     locks = []
     settings_raw.each do |dir, keys|

--- a/itchef/cookbooks/cpe_deprecation_notifier/README.md
+++ b/itchef/cookbooks/cpe_deprecation_notifier/README.md
@@ -10,7 +10,7 @@ Attributes
 ----------
 * node['cpe_deprecation_notifier']['enable']
 * node['cpe_deprecation_notifier']['path']
-* node['cpe_deprecation_notifier']['pkg_reciept']
+* node['cpe_deprecation_notifier']['pkg_receipt']
 * node['cpe_deprecation_notifier']['checksum']
 * node['cpe_deprecation_notifier']['expected_version']
 * node['cpe_deprecation_notifier']['instruction_url']
@@ -33,7 +33,7 @@ Define version to install:
 
 ```
 {
-  'pkg_reciept' => 'com.CPE.deprecationnotifier',
+  'pkg_receipt' => 'com.CPE.deprecationnotifier',
   'version' => '3.0',
   'checksum' =>
     '80787625f7606113c10f8af55a67c0a2cfbfd2ab34c7e7ccd1789f27785289d4',

--- a/itchef/cookbooks/cpe_deprecation_notifier/attributes/default.rb
+++ b/itchef/cookbooks/cpe_deprecation_notifier/attributes/default.rb
@@ -21,7 +21,7 @@ default['cpe_deprecation_notifier'] = {
   # Writes prompt time to a json file.
   'log_path' => nil,
   'path' => '/Applications/DeprecationNotifier.app',
-  'pkg_reciept' => 'com.deprecation_notifier',
+  'pkg_receipt' => 'com.deprecation_notifier',
   'checksum' => 'changeme',
   'version' => 'changeme',
   'conf' => {

--- a/itchef/cookbooks/cpe_deprecation_notifier/resources/cpe_deprecation_notifier.rb
+++ b/itchef/cookbooks/cpe_deprecation_notifier/resources/cpe_deprecation_notifier.rb
@@ -32,14 +32,14 @@ action :prompt do
     # Force a re-install if someone has removed the binary
     unless ::File.exist?("#{dpn['path']}/Contents/MacOS/DeprecationNotifier")
       Chef::Log.info('DeprecationNotifier not present, reinstalling')
-      shell_out("/usr/sbin/pkgutil --forget #{dpn['pkg_reciept']}")
+      shell_out("/usr/sbin/pkgutil --forget #{dpn['pkg_receipt']}")
     end
 
     # Upgrade Version
     cpe_remote_pkg 'DeprecationNotifier' do
       version dpn['version']
       checksum dpn['checksum']
-      receipt dpn['pkg_reciept']
+      receipt dpn['pkg_receipt']
       notifies :restart, "launchd[#{domain}]" if dpn['enable']
     end
   end

--- a/itchef/cookbooks/cpe_init/README.md
+++ b/itchef/cookbooks/cpe_init/README.md
@@ -25,7 +25,7 @@ appropriate.
 
 The general idea is that cookbooks are ordered least specific to most specific.
 This allows a small core team to make APIs and defaults and then let individual
-service owners' cookbooks at the end overwrite whatever they ened to. This also
+service owners' cookbooks at the end overwrite whatever they need to. This also
 ensures that all things the service owner chooses not to bother with are setup
 to sane settings by the core group at your site.
 
@@ -91,5 +91,3 @@ Contributing
 **DO NOT FORGET:** If you are calling an external cookbook Before you add an
 `include_recipe 'recipe'` statement be sure to add a `depends 'cookbook'` to the
 metadata.rb
-
-

--- a/itchef/cookbooks/cpe_launchd/resources/cpe_launchd.rb
+++ b/itchef/cookbooks/cpe_launchd/resources/cpe_launchd.rb
@@ -38,7 +38,7 @@ end
 
 def process_label(label, plist)
   return label if label.start_with?(node['cpe_launchd']['prefix'])
-  # label does have the prefix so now we preocess
+  # label does have the prefix so now we process
   append_to_cleanup(label, plist)
   if label.start_with?('com')
     label = delete_str_from_label(label, 'com')

--- a/itchef/cookbooks/cpe_munki/README.md
+++ b/itchef/cookbooks/cpe_munki/README.md
@@ -193,7 +193,7 @@ You can set these settings using `node['cpe_munki']['defaults_preferences']`:`
 end
 ```
 
-**NOTE:** Prefences can *only* be set under either the `preferences` or
+**NOTE:** Preferences can *only* be set under either the `preferences` or
 `defaults_preferences` key. The resources will fail if a setting exists in
 both hashes. As such, if you had both of the above code examples somewhere
 in your code, an error would be thrown saying that 'SoftwareRepoURL' is

--- a/itchef/cookbooks/cpe_munki/resources/cpe_munki_local.rb
+++ b/itchef/cookbooks/cpe_munki/resources/cpe_munki_local.rb
@@ -57,7 +57,7 @@ action :run do
     content gen_selfservice_plist
   end
 
-  # This file is for context for users to know whats avalible for their machine
+  # This file is for context for users to know what's available for their machine
   pretty_json = JSON.pretty_generate(@catalog_items)
   file '/Library/Managed Installs/munki_catalog_items.json' do
     owner 'root'
@@ -129,11 +129,11 @@ end
 
 def parse_items_in_catalogs
   catalogs = []
-  catlogs_dir = '/Library/Managed Installs/catalogs/'
-  Dir.foreach(catlogs_dir) do |catalog|
+  catalogs_dir = '/Library/Managed Installs/catalogs/'
+  Dir.foreach(catalogs_dir) do |catalog|
     next if ['.', '..'].include?(catalog)
     begin
-      p = read_plist(catlogs_dir + catalog)
+      p = read_plist(catalogs_dir + catalog)
       p.each do |d|
         catalogs << d['name']
       end

--- a/itchef/cookbooks/cpe_preferencepanes/README.md
+++ b/itchef/cookbooks/cpe_preferencepanes/README.md
@@ -37,4 +37,4 @@ node.default['cpe_preferencepanes']['HiddenPreferencePanes'] = [
 ]
 ```
 
-CFBundleIdentifers are [documented on Apple's developer site](https://developer.apple.com/documentation/devicemanagement/systempreferences).
+CFBundleIdentifiers are [documented on Apple's developer site](https://developer.apple.com/documentation/devicemanagement/systempreferences).

--- a/itchef/cookbooks/cpe_profiles/README.md
+++ b/itchef/cookbooks/cpe_profiles/README.md
@@ -55,7 +55,7 @@ means this cookbook should be run first before `cpe_profiles_local` in your
 run list (and before any other cookbook you're intending to use).
 
 Note that the default `prefix` attribute is a *dummy* value that will
-be dynamically replaced by the desitnation cookbook's prefix using a simple
+be dynamically replaced by the destination cookbook's prefix using a simple
 string substitution in both the top-level profile Hash key and the
 `ProfileIdentifier` key in the contained profile Hash.
 
@@ -66,8 +66,8 @@ all at once with a single switchover via `default_cookbook`. Use it like this:
 
 ```
 prefix = node['cpe_profiles']['prefix']
-node.deafult['cpe_profiles']['cookbook_map']["#{prefix}.myprofile"] = 'mdm_profiles'
+node.default['cpe_profiles']['cookbook_map']["#{prefix}.myprofile"] = 'mdm_profiles'
 ```
 
 This would map `"#{prefix}.myprofile"` to use the `mdm_profiles` cookbook, for
-exmaple instead of being re-written to use the `default_cookbook`.
+example instead of being re-written to use the `default_cookbook`.

--- a/itchef/cookbooks/cpe_remote/spec/cpe_remote_specs.rb
+++ b/itchef/cookbooks/cpe_remote/spec/cpe_remote_specs.rb
@@ -35,7 +35,7 @@ describe CPE::Remote do
         end
       end
     end
-    context 'When expection is raised' do
+    context 'When exception is raised' do
       it 'should return false' do
         allow(Chef::HTTP::Simple).
           to receive_message_chain(:new, :head).and_raise('boom')

--- a/itchef/cookbooks/fb_helpers/README.md
+++ b/itchef/cookbooks/fb_helpers/README.md
@@ -583,4 +583,4 @@ that, assuming the OS run has succeeded, will be a Tier run.
 If you'd like to log whenever a reboot is triggered by `fb_helpers_reboot` you
 can set `node['fb_helpers']['reboot_logging_callback']` to perform the logging.
 This should be a proc or library taking `node` (the node object), `reasons` (an
-explanatory message), `action` (the actual action being taked, e.g. `reboot`).
+explanatory message), `action` (the actual action being taken, e.g. `reboot`).

--- a/itchef/cookbooks/fb_helpers/libraries/fb_helpers.rb
+++ b/itchef/cookbooks/fb_helpers/libraries/fb_helpers.rb
@@ -27,7 +27,7 @@ module FB
     #   commentify(text, argHash)
     #
     # Arguments:
-    #   text:    Required string. The string to convert to a commnent
+    #   text:    Required string. The string to convert to a comment
     #   arghash: An optional hash with the following (optional) keys:
     #   arghash['start']:     String to use for starting comment char(s)
     #                         Defaults to '#'
@@ -278,7 +278,7 @@ If the has is specified, it takes one or more of the following keys:
     # Arguments:
     #   merge_onto: Required hash. The base hash that will be merged onto
     #   merge_with: Required hash. The hash that will be merged on merge_onto
-    #   overwrite_leaves: Optiona boolean. Whether to overwrite leaves or not
+    #   overwrite_leaves: Optional boolean. Whether to overwrite leaves or not
     def self.merge_hash(merge_onto, merge_with, overwrite_leaves = false)
       self.merge_hash!(safe_dup(merge_onto), safe_dup(merge_with),
                        overwrite_leaves)


### PR DESCRIPTION
Various minor spelling corrections to put extra polish on docstrings, comments, and readmes.

/kind documentation

```release-note
NONE
```
