### PR TITLE
Cpe chrome fixes

### DIFF
--- a/itchef/cookbooks/cpe_chrome/resources/cpe_chrome_win.rb
+++ b/itchef/cookbooks/cpe_chrome/resources/cpe_chrome_win.rb
@@ -24,7 +24,10 @@ action :config do
   # chrome is installed on all machines
   chrome_installed = ::File.file?(
     "#{ENV['ProgramFiles(x86)']}\\Google\\Chrome\\Application\\chrome.exe",
-  )
+  ) || ::File.file?(
+    "#{ENV['ProgramFiles']}\\Google\\Chrome\\Application\\chrome.exe",
+  ) || !node['cpe_chrome']['validate_installed']
+
   return unless chrome_installed || node.installed?('Google Chrome')
   return unless node['cpe_chrome']['profile'].values.any?
 
@@ -255,10 +258,10 @@ action :config do
     'c:\\Program Files (x86)\\Google\\Chrome\\Application\\master_preferences'
   file "delete-#{master_path}" do
     only_if do
-      node['cpe_chrome']['mp']['FileContents'].
-        to_hash.
-        reject { |_k, v| v.nil? }.
-        empty?
+      node['cpe_chrome']['mp']['FileContents']
+        .to_hash
+        .compact
+        .empty?
     end
     path master_path
     action :delete
@@ -281,16 +284,16 @@ action :config do
   # Create the Master Preferences file
   file "create-#{master_path}" do # ~FB023
     not_if do
-      node['cpe_chrome']['mp']['FileContents'].
-        to_hash.
-        reject { |_k, v| v.nil? }.
-        empty?
+      node['cpe_chrome']['mp']['FileContents']
+        .to_hash
+        .compact
+        .empty?
     end
     content lazy {
       Chef::JSONCompat.to_json_pretty(
-        node['cpe_chrome']['mp']['FileContents'].
-        to_hash.
-        reject { |_k, v| v.nil? },
+        node['cpe_chrome']['mp']['FileContents']
+        .to_hash
+        .compact
       )
     }
     path master_path


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

* Bug: presently a chrome extension profile with `nil` values is passed to profile cookbook unaltered. Fixed by properly compacting nested chrome extension profiles. 

* Bug: Better check for if Chrome is installed on Windows - checks vanilla `Program Files` and respects `validate_installed`.

* Style: Replaces `Hash.reject { |_k, v| v.nil? }` with `Hash.compact`.

* Bug: presently if both master prefs and profile prefs are not defined, an old master prefs file might still be left on disk. Additionally, if master prefs are defined but profile prefs are not, a entirely empty profile may still be sent to profiles cookbook. Resolved by always executing master prefs management - it should never no-op - before no-oping on an empty profile prefs definition.

**Special notes for your reviewer**:

Tested within our macOS/Windows fleet.

**Does this PR introduce a user-facing change?**:

It might fix a broken chrome extensions profile!
