### PR TITLE
Removing dependency on fb_osquery

### DIFF
--- a/itchef/cookbooks/cpe_chrome/metadata.rb
+++ b/itchef/cookbooks/cpe_chrome/metadata.rb
@@ -10,4 +10,3 @@ version '0.1.0'
 
 depends 'cpe_profiles'
 depends 'cpe_helpers'
-depends 'fb_osquery'


### PR DESCRIPTION
Doesn't look like this is needed and was added by mistake. Removing.

Issue #261