### PR TITLE
Add `supports mac_os_x` to `fb_helpers/metadata.rb`

### DIFF
--- a/itchef/cookbooks/fb_helpers/metadata.rb
+++ b/itchef/cookbooks/fb_helpers/metadata.rb
@@ -10,5 +10,6 @@ long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
 version '0.1.0'
 supports 'centos'
 supports 'debian'
-supports 'ubuntu'
 supports 'freebsd'
+supports 'mac_os_x'
+supports 'ubuntu'


### PR DESCRIPTION
- Add `supports mac_os_x` to `fb_helpers/metadata.rb`
- Alphabetize `supports` list

**What type of PR is this?**
cleanup

**What this PR does / why we need it**:
`fb_helpers` is quite clearly designed with macOS in mind so the `metadata.rb` file should reflect support for that platform.

**Special notes for your reviewer**:
👋 

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

**Additional documentation e.g., Design Proposals, usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
Design Proposals or supporting documentation, please reference a specific commit
and avoid linking directly to the master branch. This ensures that links reference
a specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [Design Proposals]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
