### PR TITLE
Add Chrome policies ManagedConfigurationPerOrigin and WebAppInstallForceList

### DIFF
--- a/itchef/cookbooks/cpe_chrome/libraries/chrome_windows.rb
+++ b/itchef/cookbooks/cpe_chrome/libraries/chrome_windows.rb
@@ -247,6 +247,8 @@ module CPE
       JSONIFY_REG_KEYS = {
         'Chrome' => {
           'ManagedBookmarks' => :string,
+          'ManagedConfigurationPerOrigin' => :string,
+          'WebAppInstallForceList' => :string,
         },
       }.freeze
     end

--- a/itchef/cookbooks/cpe_chrome/libraries/gen_windows_chrome_known_settings.rb
+++ b/itchef/cookbooks/cpe_chrome/libraries/gen_windows_chrome_known_settings.rb
@@ -1,3 +1,7 @@
+#
+# Cookbook Name:: cpe_chrome
+# Library:: gen_windows_chrome_known_settings
+#
 # Copyright (c) Facebook, Inc. and its affiliates.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -11,9 +15,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
-# Cookbook Name:: cpe_chrome
-# Library:: gen_windows_chrome_known_settings
+#
 # rubocop:disable Metrics/LineLength
 # @generated
 require_relative 'windows_chrome_settingv2'
@@ -274,12 +276,6 @@ module CPE
           :dword,
           false,
         ),
-        'ChromeVariations' => WindowsChromeFlatSetting.new(
-          'HKEY_LOCAL_MACHINE\Software\Policies\Google\Chrome',
-          'ChromeVariations',
-          :dword,
-          false,
-        ),
         'ClickToCallEnabled' => WindowsChromeFlatSetting.new(
           'HKEY_LOCAL_MACHINE\Software\Policies\Google\Chrome',
           'ClickToCallEnabled',
@@ -313,12 +309,6 @@ module CPE
         'CloudPrintSubmitEnabled' => WindowsChromeFlatSetting.new(
           'HKEY_LOCAL_MACHINE\Software\Policies\Google\Chrome',
           'CloudPrintSubmitEnabled',
-          :dword,
-          false,
-        ),
-        'CloudReportingEnabled' => WindowsChromeFlatSetting.new(
-          'HKEY_LOCAL_MACHINE\Software\Policies\Google\Chrome',
-          'CloudReportingEnabled',
           :dword,
           false,
         ),
@@ -1556,6 +1546,24 @@ module CPE
           'HKEY_LOCAL_MACHINE\Software\Policies\Google\Chrome',
           'TotalMemoryLimitMb',
           :dword,
+          false,
+        ),
+        'CloudReportingEnabled' => WindowsChromeFlatSetting.new(
+          'HKEY_LOCAL_MACHINE\Software\Policies\Google\Chrome',
+          'CloudReportingEnabled',
+          :dword,
+          false,
+        ),
+        'ChromeVariations' => WindowsChromeFlatSetting.new(
+          'HKEY_LOCAL_MACHINE\Software\Policies\Google\Chrome',
+          'ChromeVariations',
+          :dword,
+          false,
+        ),
+        'ManagedConfigurationPerOrigin' => WindowsChromeFlatSetting.new(
+          'HKEY_LOCAL_MACHINE\Software\Policies\Google\Chrome',
+          'ManagedConfigurationPerOrigin',
+          :string,
           false,
         ),
       }.freeze

--- a/itchef/cookbooks/cpe_chrome/scripts/win_chrome_manual_policy.reg
+++ b/itchef/cookbooks/cpe_chrome/scripts/win_chrome_manual_policy.reg
@@ -4,3 +4,5 @@
 [HKEY_LOCAL_MACHINE\Software\Policies\Google\Chrome]
 "TotalMemoryLimitMb"=dword:00000400
 "CloudReportingEnabled"=dword:00000000
+"ChromeVariations"=dword:00000001
+"ManagedConfigurationPerOrigin"="[]"

--- a/itchef/cookbooks/cpe_chrome/scripts/windows_policy_gen.rb
+++ b/itchef/cookbooks/cpe_chrome/scripts/windows_policy_gen.rb
@@ -88,7 +88,7 @@ module CPE
     module KnownSettings
       GENERATED = {
       <% known_settings.map do |k,v| -%>
-        "<%= k -%>" => <%= v.generated_form.tr('"', '') -%>,
+        '<%= k -%>' => <%= v.generated_form.tr('"', '') -%>,
       <% end -%>
       }.freeze
     end


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/facebook/IT-CPE/blob/master/CONTRIBUTING.md
2. Please label this pull request according to what type of issue you are addressing
3. Ensure you have added or ran the appropriate tests for your PR
-->

**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
This PR adds support for the Chrome policies ManagedConfigurationPerOrigin and WebAppInstallForceList.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
* Fixes issue that prevents the Chrome policies ManagedConfigurationPerOrigin and WebAppInstallForceList from applying on Windows machines.
* Adds the ChromeVariations and ManagedConfigurationPerOrigin policies to win_chrome_manual_policy.reg to ensure these policies don't get overwritten by windows_policy_gen.rb.
* Replace double quote with single quote under windows_policy_gen.rb to confirm with the existing formatting of gen_windows_chrome_known_settings.rb
* Regenerate gen_windows_chrome_known_settings.rb using the updated windows_policy_gen.rb.

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```

**Additional documentation e.g., Design Proposals, usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
Design Proposals or supporting documentation, please reference a specific commit
and avoid linking directly to the master branch. This ensures that links reference
a specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [Design Proposals]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
