### PR TITLE
Refactor logged_on_user_sid to support Windows Server 2019

### DIFF
--- a/itchef/cookbooks/cpe_helpers/libraries/cpe_helpers.rb
+++ b/itchef/cookbooks/cpe_helpers/libraries/cpe_helpers.rb
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-
+include Chef::Mixin::PowershellOut
 module CPE
   class Helpers
     LOGON_REG_KEY =
@@ -269,7 +269,8 @@ module CPE
     end
 
     def self.logged_on_user_sid
-      logged_on_user_registry['LastLoggedOnUserSID']
+      ps_cmd = "Get-LocalUser -Name \"#{logged_on_user_name}\" | Select-Object SID | % { $_.SID.Value }"
+      powershell_out(ps_cmd).stdout.strip
     end
 
     def self.ldap_lookup_script(username)


### PR DESCRIPTION
In its current state, `CPE::Helpers.logged_on_user_sid` returns `nil` on Windows Server 2019 because `CPE::Helpers.logged_on_user_sid` is searching for a registry value `LastLoggedOnUserSID` in `CPE::Helpers.logged_on_user_registry` that doesn't exist in that version of the operating system. To fix this, the code is being refactored to use PowerShell command to retrieve the SID of the current logged in user. This code also works with earlier versions of Windows Server and Windows 10 endpoints.

**What type of PR is this?**
/kind bug


**What this PR does / why we need it**:
Without this, Windows Server 2019 will return `nil` for CPE::Helpers.logged_on_user_sid

**Which issue(s) this PR fixes**:
<!--
*No current issues have been submitted that this PR will fix. It was discovered locally when trying to run cpe_helpers against Windows Server 2019*
-->
Fixes #

**Special notes for your reviewer**:
This will require a Windows Server 2019 host to test on

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```

**Additional documentation e.g., Design Proposals, usage docs, etc.**:

<!--
-->
```docs

```
