### PR TITLE
Rename deprecated mirrorlist..centos.org api

### DIFF
--- a/itchef/cookbooks/cpe_kernel_channel/resources/fedora.rb
+++ b/itchef/cookbooks/cpe_kernel_channel/resources/fedora.rb
@@ -43,7 +43,7 @@ action :update do
 
   yum_repository 'CentOS-BaseOS' do
     description "CentOS-#{release} - Base"
-    mirrorlist 'http://mirrorlist.centos.org/' +
+    mirrorlist 'http://vault.centos.org/' +
       "?release=#{release}&arch=$basearch&repo=BaseOS"
     fastestmirror_enabled true
     gpgkey 'file:///etc/pki/rpm-gpg/RPM-GPG-KEY-centosofficial'

--- a/itchef/cookbooks/cpe_kernel_channel/resources/fedora.rb
+++ b/itchef/cookbooks/cpe_kernel_channel/resources/fedora.rb
@@ -34,8 +34,8 @@ action :update do
 
   cookbook_file '/etc/pki/rpm-gpg/RPM-GPG-KEY-centosofficial' do
     source 'centos_kernel/RPM-GPG-KEY-centosofficial'
-    owner 'root'
-    group 'root'
+    owner node.root_user
+    group node.root_group
     mode '0644'
   end
 


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
Replace deprecated mirrorlist..centos.org with vault.centos.org after support of centOS8 has ended.

**Which issue(s) this PR fixes**:
Fixes [#281](https://github.com/facebook/IT-CPE/issues/281)

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
NONE


**Additional documentation e.g., Design Proposals, usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
Design Proposals or supporting documentation, please reference a specific commit
and avoid linking directly to the master branch. This ensures that links reference
a specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [Design Proposals]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
